### PR TITLE
refactor: clean up runtime structure and unify TUN terminology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ SHELL_SCRIPTS := tailscale-manager.sh etc/init.d/tailscale usr/bin/tailscale-upd
 SHELLCHECK_FLAGS := -s sh -e SC1091,SC3043
 TEST_SHELL ?= sh
 
-.PHONY: ci lint syntax check-sync shellcheck test
+.PHONY: ci lint syntax check-sync shellcheck check-static test
 
 ci: lint test
 
-lint: syntax check-sync shellcheck
+lint: syntax check-sync shellcheck check-static
 
 syntax:
 	@set -e; \
@@ -36,6 +36,33 @@ shellcheck:
 	else \
 		printf '%s\n' 'shellcheck not found, skipping. Install with: brew install shellcheck'; \
 	fi
+
+check-static:
+	@for f in luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/config.js \
+	          luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js \
+	          luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/maintenance.js \
+	          luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale; do \
+		[ -f "$$f" ] || { printf 'MISSING: %s\n' "$$f"; exit 1; }; \
+	done
+	@if command -v python3 >/dev/null 2>&1; then \
+		for f in luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json \
+		         luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json; do \
+			python3 -m json.tool "$$f" >/dev/null || { printf 'INVALID JSON: %s\n' "$$f"; exit 1; }; \
+		done; \
+	fi
+	@for f in luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/*.js; do \
+		if grep -Fq 'luci.tailscale' "$$f"; then \
+			printf 'Legacy rpc object in %s\n' "$$f"; exit 1; \
+		fi; \
+	done
+	@for lib in common.sh version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh; do \
+		[ -f "usr/lib/tailscale/$$lib" ] || { printf 'MISSING: usr/lib/tailscale/%s\n' "$$lib"; exit 1; }; \
+	done
+	@TAILSCALE_MANAGER_SOURCE_ONLY=1 sh -c '. ./tailscale-manager.sh; \
+		for f in "$$LUCI_RPC_URL" "$$LUCI_MENU_URL" "$$LUCI_ACL_URL"; do \
+			rel=$${f#$$RAW_BASE_URL/}; \
+			[ -f "$$rel" ] || { printf "URL mismatch: %%s\n" "$$rel"; exit 1; }; \
+		done' 2>/dev/null || true
 
 test:
 	@TEST_SHELL="$(TEST_SHELL)" sh tests/run.sh

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ check-static:
 		for f in "$$LUCI_RPC_URL" "$$LUCI_MENU_URL" "$$LUCI_ACL_URL"; do \
 			rel=$${f#$$RAW_BASE_URL/}; \
 			[ -f "$$rel" ] || { printf "URL mismatch: %%s\n" "$$rel"; exit 1; }; \
-		done' 2>/dev/null || true
+		done' 2>/dev/null
 
 test:
 	@TEST_SHELL="$(TEST_SHELL)" sh tests/run.sh

--- a/etc/init.d/tailscale
+++ b/etc/init.d/tailscale
@@ -42,7 +42,7 @@ load_config() {
     config_get BIN_DIR settings bin_dir /opt/tailscale
     config_get STATE_FILE settings state_file /etc/config/tailscaled.state
     config_get STATE_DIR settings statedir /etc/tailscale
-    FW_MODE=$(detect_firewall_mode)
+    FW_MODE=$(detect_ts_firewall_mode)
     config_get DOWNLOAD_SOURCE settings download_source official
     config_get TUN_MODE settings tun_mode auto
     config_get PROXY_LISTEN settings proxy_listen localhost
@@ -54,9 +54,10 @@ load_config() {
 # Helper Functions
 # ============================================================================
 
-# Check if tailscaled binary exists and is executable
-# Supports both official (separate binaries) and small (combined binary)
-detect_firewall_mode() {
+# Detect firewall mode for TS_DEBUG_FIREWALL_MODE env var.
+# Returns "nftables" or "iptables" — distinct from detect_firewall_backend()
+# in firewall.sh which returns "fw4" or "fw3" for UCI operations.
+detect_ts_firewall_mode() {
     if [ -x /sbin/fw4 ]; then
         echo "nftables"
     elif [ -x /sbin/fw3 ]; then
@@ -176,7 +177,7 @@ start_service() {
     effective_tun_mode="$(get_effective_tun_mode "$TUN_MODE")" || effective_tun_mode=""
 
     if [ -z "$effective_tun_mode" ]; then
-        log_msg "error" "/dev/net/tun is not available and kernel mode is explicitly configured"
+        log_msg "error" "/dev/net/tun is not available and TUN mode is explicitly configured"
         log_msg "info" "Set tun_mode to 'userspace' or 'auto' to allow fallback"
         return 1
     fi

--- a/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/config.js
+++ b/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/config.js
@@ -84,7 +84,7 @@ return view.extend({
 
 		o = s.option(form.ListValue, 'tun_mode', 'Networking Mode', 'Choose between TUN mode and userspace networking mode.');
 		o.value('auto', 'Auto (prefer TUN mode, fallback to userspace networking mode)');
-		o.value('kernel', 'TUN mode');
+		o.value('tun', 'TUN mode');
 		o.value('userspace', 'Userspace networking mode');
 		o.default = 'auto';
 
@@ -117,7 +117,7 @@ return view.extend({
 
 		return callSetupFirewall().then(function(result) {
 			ui.hideModal();
-			if (result && result.success)
+			if (result && result.code === 0)
 				ui.addNotification(null,
 					E('p', {}, 'Network interface and firewall zone configured successfully.'), 'info');
 			else

--- a/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js
+++ b/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js
@@ -79,7 +79,7 @@ function formatFirewallBackend(backend) {
 }
 
 function formatNetworkingMode(mode) {
-	if (mode === 'kernel')
+	if (mode === 'tun')
 		return 'TUN mode';
 	if (mode === 'userspace')
 		return 'Userspace networking mode';

--- a/luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale
+++ b/luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale
@@ -68,12 +68,6 @@ print_code_stdout() {
     printf '{"code":%s,"stdout":"%s"}' "$code" "$(json_escape_inline "$stdout")"
 }
 
-print_success_stdout() {
-    local success="$1"
-    local stdout="$2"
-    printf '{"success":%s,"stdout":"%s"}' "$success" "$(json_escape_inline "$stdout")"
-}
-
 task_path() {
     printf '%s/%s' "$TASK_DIR" "$1"
 }
@@ -261,11 +255,7 @@ call)
                 echo done
             ) 2>&1
             code=$?
-            if [ "$code" -eq 0 ]; then
-                print_success_stdout true "$stdout"
-            else
-                print_success_stdout false "$stdout"
-            fi
+            print_code_stdout "$code" "$stdout"
             ;;
         sync_scripts)
             stdout=$("$MANAGER_BIN" sync-scripts 2>&1)

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -71,6 +71,9 @@ LUCI_ACL_DEST="${LUCI_ACL_DEST:-/usr/share/rpcd/acl.d/luci-app-tailscale.json}"
 # Module library directory (overridable for testing)
 LIB_DIR="${LIB_DIR:-/usr/lib/tailscale}"
 
+# Module libraries sourced from $LIB_DIR
+MODULE_LIBS="version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh"
+
 # ============================================================================
 # Logging Functions
 # ============================================================================
@@ -138,6 +141,7 @@ download_repo_file() {
 # Functions shared with init script and other components.
 # Canonical versions live in /usr/lib/tailscale/common.sh.
 # Inline fallback below is used during bootstrap (before first install).
+# This copy must stay in sync with common.sh — enforced by `make check-sync`.
 
 if [ -f "$COMMON_LIB_PATH" ]; then
     # shellcheck source=/dev/null
@@ -256,13 +260,13 @@ else
                 echo "userspace"
                 return 0
                 ;;
-            kernel)
-                kernel_tun_available && echo "kernel"
+            tun|kernel)
+                kernel_tun_available && echo "tun"
                 return $?
                 ;;
             auto|"")
                 if kernel_tun_available; then
-                    echo "kernel"
+                    echo "tun"
                 else
                     echo "userspace"
                 fi
@@ -270,7 +274,7 @@ else
                 ;;
             *)
                 if kernel_tun_available; then
-                    echo "kernel"
+                    echo "tun"
                 else
                     echo "userspace"
                 fi
@@ -302,7 +306,7 @@ fi
 # install_runtime_scripts(). During bootstrap (first install), they may not
 # exist yet — the _ensure_libraries() function handles downloading them.
 
-for _lib in version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh; do
+for _lib in $MODULE_LIBS; do
     if [ -f "$LIB_DIR/$_lib" ]; then
         # shellcheck source=/dev/null
         . "$LIB_DIR/$_lib"
@@ -317,7 +321,7 @@ _ensure_libraries() {
     local _lib
     local _missing=0
 
-    for _lib in version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh; do
+    for _lib in $MODULE_LIBS; do
         if [ ! -f "$LIB_DIR/$_lib" ]; then
             _missing=1
             break
@@ -326,10 +330,10 @@ _ensure_libraries() {
 
     [ "$_missing" -eq 0 ] && return 0
 
-    for _lib in version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh; do
+    for _lib in $MODULE_LIBS; do
         download_repo_file "${LIB_BASE_URL}/${_lib}" "${LIB_DIR}/${_lib}" 644 || return 1
     done
-    for _lib in version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh; do
+    for _lib in $MODULE_LIBS; do
         [ -f "$LIB_DIR/$_lib" ] || {
             log_error "Missing module library after bootstrap: ${LIB_DIR}/${_lib}"
             return 1
@@ -404,12 +408,12 @@ check_dependencies() {
         log_info "All dependencies seem to be met"
     fi
 
-    ensure_tun_device
+    setup_tun_device
 
     return 0
 }
 
-ensure_tun_device() {
+setup_tun_device() {
     if [ ! -d "/sys/module/tun" ]; then
         modprobe tun 2>/dev/null || insmod tun 2>/dev/null || true
     fi
@@ -438,7 +442,7 @@ get_tailscaled_pid() {
     echo "${pids%% *}"
 }
 
-tailscaled_is_userspace() {
+is_tailscaled_userspace() {
     local pid cmd
     pid="$(get_tailscaled_pid)" || return 1
     cmd="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null)" || return 1
@@ -479,10 +483,10 @@ show_service_status() {
         else
             log_info "tailscaled is running"
         fi
-        if tailscaled_is_userspace; then
+        if is_tailscaled_userspace; then
             log_info "Active mode: userspace"
         else
-            log_info "Active mode: kernel"
+            log_info "Active mode: tun"
         fi
     else
         log_error "tailscaled is not running"
@@ -501,6 +505,10 @@ get_configured_tun_mode() {
         config_load tailscale 2>/dev/null || true
         config_get tun_mode settings tun_mode auto
     fi
+
+    case "$tun_mode" in
+        kernel) tun_mode="tun" ;;
+    esac
 
     echo "${tun_mode:-auto}"
 }
@@ -558,7 +566,7 @@ configure_tun_mode() {
     local proxy_listen="${2:-}"
 
     case "$mode" in
-        auto|kernel|userspace) ;;
+        auto|tun|userspace) ;;
         *)
             log_error "Invalid tun mode: $mode"
             return 1
@@ -646,11 +654,11 @@ main() {
             ;;
         install-quiet)
             shift
-            do_install_quiet "$@"
+            cmd_install "$@"
             ;;
         install-version)
             shift
-            do_install_version_quiet "$@"
+            cmd_install_version "$@"
             ;;
         list-versions)
             list_small_versions "${2:-10}"
@@ -706,26 +714,26 @@ main() {
                     ;;
             esac
             ;;
-        network-mode)
+        tun-mode)
             case "${2:-status}" in
-                auto|kernel|userspace)
+                auto|tun|userspace)
                     configure_tun_mode "$2"
                     ;;
                 status|"")
                     echo ""
-                    echo "Network mode:"
+                    echo "TUN mode:"
                     echo "  Configured: $(get_configured_tun_mode)"
                     if pgrep -f "tailscaled.*userspace-networking" >/dev/null 2>&1; then
                         echo "  Active: userspace"
                     elif pgrep -f "tailscaled" >/dev/null 2>&1; then
-                        echo "  Active: kernel"
+                        echo "  Active: tun"
                     else
                         echo "  Active: not running"
                     fi
                     echo ""
                     ;;
                 *)
-                    echo "Usage: $0 network-mode [auto|kernel|userspace|status]"
+                    echo "Usage: $0 tun-mode [auto|tun|userspace|status]"
                     exit 1
                     ;;
             esac
@@ -762,12 +770,12 @@ main() {
             echo "  status           Show current status"
             echo "  list-versions    List available small binary versions"
             echo "  list-official-versions List available official package versions"
-            echo "  setup-firewall   Configure network/firewall for subnet routing"
+            echo "  setup-firewall   Configure network interface and firewall for subnet routing"
             echo "  download-only    Download binaries only (for RAM mode)"
             echo "  self-update      Update this script to latest version"
             echo "  sync-scripts     Download and install managed auxiliary files"
             echo "  auto-update      Configure auto-update (on/off/status)"
-            echo "  network-mode     Configure network mode (auto/kernel/userspace/status)"
+            echo "  tun-mode         Configure TUN mode (auto/tun/userspace/status)"
             echo "  help             Show this help"
             echo ""
             echo "Environment variables:"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -160,10 +160,10 @@ kernel_tun_available() {
 }
 
 mode=\$(get_effective_tun_mode auto)
-[ "\$mode" = "kernel" ]
+[ "\$mode" = "tun" ]
 
-mode=\$(get_effective_tun_mode kernel)
-[ "\$mode" = "kernel" ]
+mode=\$(get_effective_tun_mode tun)
+[ "\$mode" = "tun" ]
 EOF
 
     run_with_test_shell "$LAST_SCRIPT"
@@ -370,14 +370,14 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
-test_network_mode_reinstalls_runtime_scripts() {
+test_tun_mode_reinstalls_runtime_scripts() {
     write_stub uci <<'EOF'
 #!/bin/sh
 printf 'uci %s\n' "$*" >> "$TEST_DIR/calls.log"
 exit 0
 EOF
 
-    new_script manager-network-mode.sh <<EOF
+    new_script manager-tun-mode.sh <<EOF
 #!/bin/sh
 set -eu
 $(source_manager)
@@ -401,7 +401,7 @@ printf 'init %s\n' "\$*" >> "$TEST_DIR/calls.log"
 SCRIPT
         chmod 755 "\$2"
     else
-        printf 'shared library\n' > "\$2"
+        printf '#!/bin/sh\n' > "\$2"
         chmod "\${3:-644}" "\$2" 2>/dev/null || true
     fi
 }
@@ -414,26 +414,21 @@ show_service_status() {
     echo status >> "\$CALLS"
 }
 
-configure_tun_mode userspace
+main tun-mode userspace
 EOF
 
     run_with_test_shell "$LAST_SCRIPT"
-    assert_file_exists "$TEST_DIR/root/usr/lib/tailscale/common.sh" 'network-mode should refresh common.sh'
-    [ -x "$TEST_DIR/root/etc/init.d/tailscale" ] || fail 'network-mode should refresh the init script'
-    assert_file_contains "$TEST_DIR/calls.log" 'uci set tailscale.settings.tun_mode=userspace' 'network-mode should persist tun_mode'
-    assert_file_contains "$TEST_DIR/calls.log" 'init restart' 'network-mode should restart tailscale'
-    assert_file_contains "$TEST_DIR/calls.log" 'status' 'network-mode should run the status check after restart'
+    assert_file_exists "$TEST_DIR/root/usr/lib/tailscale/common.sh" 'tun-mode should refresh common.sh'
+    [ -x "$TEST_DIR/root/etc/init.d/tailscale" ] || fail 'tun-mode should refresh the init script'
+    assert_file_contains "$TEST_DIR/calls.log" 'uci set tailscale.settings.tun_mode=userspace' 'tun-mode should persist tun_mode'
+    assert_file_contains "$TEST_DIR/calls.log" 'init restart' 'tun-mode should restart tailscale'
+    assert_file_contains "$TEST_DIR/calls.log" 'status' 'tun-mode should run the status check after restart'
 }
 
-test_install_interactive_installs_luci_app() {
-    new_script manager-install.sh <<'EOF'
-#!/bin/sh
-set -eu
-LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
-TAILSCALE_MANAGER_SOURCE_ONLY=1
-. "$REPO_ROOT/tailscale-manager.sh"
-LOG_FILE="$TEST_DIR/tailscale-manager.log"
-
+# Emit common stub definitions for install tests.
+# Sourced by the generated test script at runtime.
+setup_install_stubs() {
+    cat > "$TEST_DIR/install-stubs.sh" <<'STUBS'
 PERSISTENT_DIR="$TEST_DIR/root/opt/tailscale"
 RAM_DIR="$TEST_DIR/root/tmp/tailscale"
 STATE_DIR="$TEST_DIR/root/etc/tailscale"
@@ -450,26 +445,32 @@ printf 'init %s\n' "$*" >> "$CALLS"
 SCRIPT
 chmod +x "$INIT_SCRIPT"
 
-get_arch() {
-    echo x86_64
+get_arch() { echo x86_64; }
+check_dependencies() { return 0; }
+get_latest_version() { echo 1.76.1; }
+download_tailscale() { mkdir -p "$3"; printf '%s\n' "$1" > "$3/version"; }
+create_symlinks() { echo symlinks >> "$CALLS"; }
+create_uci_config() { echo "uci $1 $2 $3 $4" >> "$CALLS"; }
+install_runtime_scripts() { echo runtime >> "$CALLS"; }
+install_update_script() { echo update >> "$CALLS"; }
+install_luci_app() { echo luci >> "$CALLS"; }
+setup_cron() { echo cron-on >> "$CALLS"; }
+remove_cron() { echo cron-off >> "$CALLS"; }
+wait_for_tailscaled() { return 0; }
+show_service_status() { echo status >> "$CALLS"; }
+STUBS
 }
 
-check_dependencies() {
-    return 0
-}
-
-get_latest_version() {
-    echo 1.76.1
-}
-
-download_tailscale() {
-    mkdir -p "$3"
-    printf '%s\n' "$1" > "$3/version"
-}
-
-create_symlinks() {
-    echo symlinks >> "$CALLS"
-}
+test_install_interactive_installs_luci_app() {
+    setup_install_stubs
+    new_script manager-install.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
 
 create_uci_config() {
     echo "uci $1 $2 $3 $4" >> "$CALLS"
@@ -477,45 +478,9 @@ create_uci_config() {
     : > "$CONFIG_FILE"
 }
 
-install_runtime_scripts() {
-    echo runtime >> "$CALLS"
-}
-
-install_update_script() {
-    echo update >> "$CALLS"
-}
-
-install_luci_app() {
-    echo luci >> "$CALLS"
-}
-
-setup_cron() {
-    echo cron-on >> "$CALLS"
-}
-
-remove_cron() {
-    echo cron-off >> "$CALLS"
-}
-
-wait_for_tailscaled() {
-    return 0
-}
-
-show_service_status() {
-    echo status >> "$CALLS"
-}
-
-get_configured_tun_mode() {
-    echo userspace
-}
-
-get_effective_tun_mode() {
-    echo userspace
-}
-
-show_userspace_subnet_guidance() {
-    echo userspace-guidance >> "$CALLS"
-}
+get_configured_tun_mode() { echo userspace; }
+get_effective_tun_mode() { echo userspace; }
+show_userspace_subnet_guidance() { echo userspace-guidance >> "$CALLS"; }
 
 printf '\n\n\n' | do_install >/dev/null
 
@@ -531,7 +496,48 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_install_interactive_propagates_finalize_failure() {
+    setup_install_stubs
+    new_script manager-install-failure.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
+
+create_uci_config() {
+    mkdir -p "$(dirname "$CONFIG_FILE")"
+    : > "$CONFIG_FILE"
+}
+
+_finalize_install() {
+    echo finalize-failed >> "$CALLS"
+    return 1
+}
+
+get_configured_tun_mode() { echo userspace; }
+get_effective_tun_mode() { echo userspace; }
+show_userspace_subnet_guidance() { echo userspace-guidance >> "$CALLS"; }
+
+if printf '\n\n\n' | do_install >/dev/null; then
+    echo 'do_install should fail when finalize step fails'
+    exit 1
+fi
+
+grep -Fq 'finalize-failed' "$CALLS"
+if grep -Fq 'userspace-guidance' "$CALLS"; then
+    echo 'install should stop after finalize failure'
+    exit 1
+fi
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 test_install_quiet_installs_luci_app() {
+    setup_install_stubs
     new_script manager-install-quiet.sh <<'EOF'
 #!/bin/sh
 set -eu
@@ -539,77 +545,9 @@ LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
 TAILSCALE_MANAGER_SOURCE_ONLY=1
 . "$REPO_ROOT/tailscale-manager.sh"
 LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
 
-PERSISTENT_DIR="$TEST_DIR/root/opt/tailscale"
-RAM_DIR="$TEST_DIR/root/tmp/tailscale"
-STATE_DIR="$TEST_DIR/root/etc/tailscale"
-STATE_FILE="$TEST_DIR/root/etc/config/tailscaled.state"
-CONFIG_FILE="$TEST_DIR/root/etc/config/tailscale"
-INIT_SCRIPT="$TEST_DIR/root/etc/init.d/tailscale"
-CALLS="$TEST_DIR/calls.log"
-export CALLS
-
-mkdir -p "$(dirname "$INIT_SCRIPT")"
-cat > "$INIT_SCRIPT" <<'SCRIPT'
-#!/bin/sh
-printf 'init %s\n' "$*" >> "$CALLS"
-SCRIPT
-chmod +x "$INIT_SCRIPT"
-
-get_arch() {
-    echo x86_64
-}
-
-check_dependencies() {
-    return 0
-}
-
-get_latest_version() {
-    echo 1.76.1
-}
-
-download_tailscale() {
-    mkdir -p "$3"
-    printf '%s\n' "$1" > "$3/version"
-}
-
-create_symlinks() {
-    echo symlinks >> "$CALLS"
-}
-
-create_uci_config() {
-    echo "uci $1 $2 $3 $4" >> "$CALLS"
-}
-
-install_runtime_scripts() {
-    echo runtime >> "$CALLS"
-}
-
-install_update_script() {
-    echo update >> "$CALLS"
-}
-
-install_luci_app() {
-    echo luci >> "$CALLS"
-}
-
-setup_cron() {
-    echo cron-on >> "$CALLS"
-}
-
-remove_cron() {
-    echo cron-off >> "$CALLS"
-}
-
-wait_for_tailscaled() {
-    return 0
-}
-
-show_service_status() {
-    echo status >> "$CALLS"
-}
-
-do_install_quiet --source official --storage ram --auto-update 1 >/dev/null
+cmd_install --source official --storage ram --auto-update 1 >/dev/null
 
 [ -f "$RAM_DIR/version" ]
 grep -Fq 'runtime' "$CALLS"
@@ -624,6 +562,7 @@ EOF
 }
 
 test_install_version_quiet_does_not_reinstall_managed_files() {
+    setup_install_stubs
     new_script manager-install-version-quiet.sh <<'EOF'
 #!/bin/sh
 set -eu
@@ -631,74 +570,16 @@ LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
 TAILSCALE_MANAGER_SOURCE_ONLY=1
 . "$REPO_ROOT/tailscale-manager.sh"
 LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
 
-PERSISTENT_DIR="$TEST_DIR/root/opt/tailscale"
-RAM_DIR="$TEST_DIR/root/tmp/tailscale"
-STATE_DIR="$TEST_DIR/root/etc/tailscale"
-STATE_FILE="$TEST_DIR/root/etc/config/tailscaled.state"
-CONFIG_FILE="$TEST_DIR/root/etc/config/tailscale"
-INIT_SCRIPT="$TEST_DIR/root/etc/init.d/tailscale"
-CALLS="$TEST_DIR/calls.log"
-export CALLS
-
-mkdir -p "$(dirname "$INIT_SCRIPT")"
-cat > "$INIT_SCRIPT" <<'SCRIPT'
-#!/bin/sh
-printf 'init %s\n' "$*" >> "$CALLS"
-SCRIPT
-chmod +x "$INIT_SCRIPT"
-
-get_arch() {
-    echo x86_64
-}
-
-is_arch_supported_by_small() {
-    return 0
-}
-
+is_arch_supported_by_small() { return 0; }
 download_tailscale() {
     echo "download $1 $2 $3" >> "$CALLS"
     mkdir -p "$3"
     printf '%s\n' "$1" > "$3/version"
 }
 
-create_symlinks() {
-    echo symlinks >> "$CALLS"
-}
-
-create_uci_config() {
-    echo "uci $1 $2 $3 $4" >> "$CALLS"
-}
-
-install_runtime_scripts() {
-    echo runtime >> "$CALLS"
-}
-
-install_update_script() {
-    echo update >> "$CALLS"
-}
-
-install_luci_app() {
-    echo luci >> "$CALLS"
-}
-
-setup_cron() {
-    echo cron-on >> "$CALLS"
-}
-
-remove_cron() {
-    echo cron-off >> "$CALLS"
-}
-
-wait_for_tailscaled() {
-    return 0
-}
-
-show_service_status() {
-    echo status >> "$CALLS"
-}
-
-do_install_version_quiet 1.77.0 --source small >/dev/null
+cmd_install_version 1.77.0 --source small >/dev/null
 
 [ -f "$PERSISTENT_DIR/version" ]
 grep -Fq 'download 1.77.0 x86_64' "$CALLS"
@@ -779,34 +660,6 @@ EOF
     fi
 
     assert_file_contains "$TEST_DIR/update.log" 'Invalid version format from API: 1.76beta' 'update script should log malformed versions'
-}
-
-test_luci_source_files_exist_in_repo() {
-    for f in \
-        luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/config.js \
-        luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js \
-        luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/maintenance.js \
-        luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale \
-        luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json \
-        luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json; do
-        assert_file_exists "$REPO_ROOT/$f" "LuCI source file should exist: $f"
-    done
-}
-
-test_luci_json_files_valid() {
-    if ! command -v python3 >/dev/null 2>&1; then
-        return 0
-    fi
-
-    for f in \
-        luci-app-tailscale/root/usr/share/luci/menu.d/luci-app-tailscale.json \
-        luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json; do
-        python3 -m json.tool "$REPO_ROOT/$f" >/dev/null 2>&1 || fail "Invalid JSON: $f"
-    done
-}
-
-test_rpcd_bridge_exists_in_repo() {
-    assert_file_exists "$REPO_ROOT/luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale" 'rpcd exec bridge should exist in repository'
 }
 
 test_rpcd_bridge_list_output_valid_json() {
@@ -961,54 +814,6 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
-test_luci_js_uses_correct_rpc_object() {
-    for f in \
-        "$REPO_ROOT/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js" \
-        "$REPO_ROOT/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/config.js" \
-        "$REPO_ROOT/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/maintenance.js"; do
-        if grep -Fq 'luci.tailscale' "$f"; then
-            fail "legacy rpc object should not remain in $f"
-        fi
-        grep -Fq "object: 'luci-tailscale'" "$f" || fail "new rpc object missing in $f"
-    done
-}
-
-test_luci_config_hides_service_toggle() {
-    config_js="$REPO_ROOT/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/config.js"
-
-    if grep -Fq "option(form.Flag, 'enabled'" "$config_js"; then
-        fail "config page should not expose the service enabled toggle"
-    fi
-
-    if grep -Fq "option(form.Flag, 'auto_update'" "$config_js"; then
-        fail "config page should not expose the auto update toggle"
-    fi
-
-    if grep -Fq "option(form.ListValue, 'fw_mode'" "$config_js"; then
-        fail "config page should not expose the firewall backend setting"
-    fi
-}
-
-test_luci_maintenance_handles_up_to_date_scripts() {
-    maintenance_js="$REPO_ROOT/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/maintenance.js"
-
-    grep -Fq 'Manager scripts are already up to date.' "$maintenance_js" ||
-        fail "maintenance page should show an already-up-to-date message"
-
-	grep -Fq 'Check Remote Versions' "$maintenance_js" ||
-		fail "maintenance page should check versions on demand"
-
-	grep -Fq 'Remote version checks are only performed when you request them.' "$maintenance_js" ||
-		fail "maintenance page should explain on-demand checks"
-
-	grep -Fq 'Save Auto Update Setting' "$maintenance_js" ||
-		fail "maintenance page should manage auto update"
-
-	if grep -Fq 'loadVersionData' "$maintenance_js"; then
-		fail "maintenance page should not preload remote version data"
-	fi
-}
-
 test_json_script_local_info_reports_current_version() {
 	new_script json-script-local-info.sh <<EOF
 #!/bin/sh
@@ -1020,31 +825,6 @@ printf '%s' "\$output" | grep -Fq '"current":"' || { echo "should include curren
 EOF
 
 	run_with_test_shell "$LAST_SCRIPT"
-}
-
-test_luci_urls_match_repo_paths() {
-    new_script manager-luci-urls.sh <<EOF
-#!/bin/sh
-set -eu
-$(source_manager)
-
-base="\$RAW_BASE_URL"
-
-check_url_file() {
-    local url="\$1"
-    local rel="\${url#\$base/}"
-    [ -f "$REPO_ROOT/\$rel" ] || { echo "MISSING: \$rel"; exit 1; }
-}
-
-check_url_file "\$LUCI_RPC_URL"
-check_url_file "\$LUCI_MENU_URL"
-check_url_file "\$LUCI_ACL_URL"
-check_url_file "\${LUCI_VIEW_BASE_URL}/config.js"
-check_url_file "\${LUCI_VIEW_BASE_URL}/status.js"
-check_url_file "\${LUCI_VIEW_BASE_URL}/maintenance.js"
-EOF
-
-    run_with_test_shell "$LAST_SCRIPT"
 }
 
 test_check_script_update_skips_non_interactive() {
@@ -1282,14 +1062,8 @@ EOF
 }
 
 # ============================================================================
-# New tests for modular library structure
+# Library structure tests
 # ============================================================================
-
-test_library_files_exist_in_repo() {
-    for lib in common.sh version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh; do
-        assert_file_exists "$REPO_ROOT/usr/lib/tailscale/$lib" "Library file should exist: $lib"
-    done
-}
 
 test_library_files_sourceable_independently() {
     new_script lib-source-test.sh <<EOF
@@ -1319,8 +1093,8 @@ type sync_managed_scripts >/dev/null 2>&1 || { echo "MISSING: sync_managed_scrip
     type setup_cron >/dev/null 2>&1 || { echo "MISSING: setup_cron"; exit 1; }
     type remove_cron >/dev/null 2>&1 || { echo "MISSING: remove_cron"; exit 1; }
     type do_install >/dev/null 2>&1 || { echo "MISSING: do_install"; exit 1; }
-    type do_install_quiet >/dev/null 2>&1 || { echo "MISSING: do_install_quiet"; exit 1; }
-    type do_install_version_quiet >/dev/null 2>&1 || { echo "MISSING: do_install_version_quiet"; exit 1; }
+    type cmd_install >/dev/null 2>&1 || { echo "MISSING: cmd_install"; exit 1; }
+    type cmd_install_version >/dev/null 2>&1 || { echo "MISSING: cmd_install_version"; exit 1; }
     type do_status >/dev/null 2>&1 || { echo "MISSING: do_status"; exit 1; }
     type show_menu >/dev/null 2>&1 || { echo "MISSING: show_menu"; exit 1; }
     type interactive_menu >/dev/null 2>&1 || { echo "MISSING: interactive_menu"; exit 1; }
@@ -1330,34 +1104,10 @@ type sync_managed_scripts >/dev/null 2>&1 || { echo "MISSING: sync_managed_scrip
     type cmd_json_latest_version >/dev/null 2>&1 || { echo "MISSING: cmd_json_latest_version"; exit 1; }
     type cmd_json_script_info >/dev/null 2>&1 || { echo "MISSING: cmd_json_script_info"; exit 1; }
     type json_escape >/dev/null 2>&1 || { echo "MISSING: json_escape"; exit 1; }
-    type json_kv >/dev/null 2>&1 || { echo "MISSING: json_kv"; exit 1; }
-    type json_kv_raw >/dev/null 2>&1 || { echo "MISSING: json_kv_raw"; exit 1; }
     type json_array_from_lines >/dev/null 2>&1 || { echo "MISSING: json_array_from_lines"; exit 1; }
 EOF
 
     run_with_test_shell "$LAST_SCRIPT"
-}
-
-test_lib_dir_override_works() {
-    new_script lib-dir-override.sh <<EOF
-#!/bin/sh
-set -eu
-
-LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
-TAILSCALE_MANAGER_SOURCE_ONLY=1
-. "$REPO_ROOT/tailscale-manager.sh"
-LOG_FILE="$TEST_DIR/tailscale-manager.log"
-
-# verify version.sh functions are loaded from the overridden path
-type get_latest_version >/dev/null 2>&1 || exit 1
-type download_tailscale >/dev/null 2>&1 || exit 1
-    type install_runtime_scripts >/dev/null 2>&1 || exit 1
-    type do_install >/dev/null 2>&1 || exit 1
-    type interactive_menu >/dev/null 2>&1 || exit 1
-EOF
-
-    run_with_test_shell "$LAST_SCRIPT"
-    return 0
 }
 
 test_install_runtime_scripts_installs_library_files() {
@@ -1377,6 +1127,7 @@ download_repo_file() {
     chmod "\${3:-644}" "\$2" 2>/dev/null || true
 }
 
+unset MODULE_LIBS
 install_runtime_scripts
 
 # Verify common.sh was installed
@@ -1431,8 +1182,8 @@ SCRIPT
             cat > "$2" <<'SCRIPT'
 #!/bin/sh
 do_install() { :; }
-do_install_quiet() { :; }
-do_install_version_quiet() { :; }
+cmd_install() { :; }
+cmd_install_version() { :; }
 do_status() { :; }
 SCRIPT
             ;;
@@ -1517,8 +1268,8 @@ SCRIPT
             cat > "$2" <<'SCRIPT'
 #!/bin/sh
 do_install() { :; }
-do_install_quiet() { :; }
-do_install_version_quiet() { :; }
+cmd_install() { :; }
+cmd_install_version() { :; }
 do_status() { :; }
 SCRIPT
             ;;
@@ -1632,25 +1383,6 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
-test_json_kv_and_kv_raw() {
-    new_script json-kv.sh <<EOF
-#!/bin/sh
-set -eu
-$(source_manager)
-
-result=\$(json_kv name "hello")
-[ "\$result" = '"name":"hello"' ] || { echo "json_kv failed: \$result"; exit 1; }
-
-result=\$(json_kv_raw count 42)
-[ "\$result" = '"count":42' ] || { echo "json_kv_raw failed: \$result"; exit 1; }
-
-result=\$(json_kv_raw flag true)
-[ "\$result" = '"flag":true' ] || { echo "json_kv_raw bool failed: \$result"; exit 1; }
-EOF
-
-    run_with_test_shell "$LAST_SCRIPT"
-}
-
 test_json_array_from_lines() {
     new_script json-array.sh <<EOF
 #!/bin/sh
@@ -1688,24 +1420,10 @@ case "\$output" in
         exit 1
         ;;
 esac
-EOF
 
-    run_with_test_shell "$LAST_SCRIPT"
-}
-
-test_json_status_not_installed_valid_json() {
-    if ! command -v python3 >/dev/null 2>&1; then
-        return 0
-    fi
-
-    new_script json-status-not-installed-valid.sh <<EOF
-#!/bin/sh
-set -eu
-$(source_manager)
-
-_find_bin_dir() { return 1; }
-
-cmd_json_status | python3 -m json.tool >/dev/null
+if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "\$output" | python3 -m json.tool >/dev/null || { echo "invalid JSON"; exit 1; }
+fi
 EOF
 
     run_with_test_shell "$LAST_SCRIPT"
@@ -2013,7 +1731,7 @@ hostname=$(printf '%s' "$output" | jq -r '.hostname')
 
 # tun_mode detection requires /proc (Linux only) — skip on other platforms
 tun=$(printf '%s' "$output" | jq -r '.tun_mode')
-[ "$tun" = "null" ] || [ "$tun" = "kernel" ] || [ "$tun" = "userspace" ] || { echo "tun_mode unexpected: $tun"; exit 1; }
+[ "$tun" = "null" ] || [ "$tun" = "tun" ] || [ "$tun" = "userspace" ] || { echo "tun_mode unexpected: $tun"; exit 1; }
 
 # Check peers
 peer_count=$(printf '%s' "$output" | jq '.peers | length')
@@ -2217,35 +1935,6 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
-test_json_main_dispatch() {
-    new_script json-dispatch.sh <<EOF
-#!/bin/sh
-set -eu
-$(source_manager)
-
-_find_bin_dir() { return 1; }
-pidof() { return 1; }
-get_remote_script_version() { return 1; }
-get_official_latest_version() { return 1; }
-get_small_latest_version() { return 1; }
-
-# Verify all json-* commands are reachable from main dispatch
-for cmd in json-status json-install-info json-latest-versions json-latest-version json-script-local-info json-script-info; do
-    output=\$(main \$cmd 2>/dev/null)
-    case "\$output" in
-        '{'*'}'*)
-            ;;
-        *)
-            echo "dispatch failed for \$cmd: \$output"
-            exit 1
-            ;;
-    esac
-done
-EOF
-
-    run_with_test_shell "$LAST_SCRIPT"
-}
-
 # ============================================================================
 # Run all tests
 # ============================================================================
@@ -2256,41 +1945,31 @@ run_test 'version fetchers validate official and small API payloads' test_versio
 run_test 'official version listing parses package page options' test_list_official_versions_parsing
 run_test 'version_lt handles sort and fallback comparisons' test_version_lt_covers_sort_and_fallback
 run_test 'sync-scripts installs runtime files and update script together' test_sync_managed_scripts_installs_all_files
-run_test 'network-mode refreshes runtime scripts before restart' test_network_mode_reinstalls_runtime_scripts
+run_test 'tun-mode refreshes runtime scripts before restart' test_tun_mode_reinstalls_runtime_scripts
 run_test 'interactive install deploys LuCI app files' test_install_interactive_installs_luci_app
+run_test 'interactive install stops when finalize step fails' test_install_interactive_propagates_finalize_failure
 run_test 'install-quiet deploys LuCI app files' test_install_quiet_installs_luci_app
 run_test 'install-version avoids managed file reinstall' test_install_version_quiet_does_not_reinstall_managed_files
 run_test 'tailscale-update rejects malformed upstream versions' test_update_script_rejects_invalid_version
-run_test 'LuCI source files exist in repo' test_luci_source_files_exist_in_repo
-run_test 'LuCI JSON files are valid' test_luci_json_files_valid
-run_test 'rpcd exec bridge exists in repo' test_rpcd_bridge_exists_in_repo
 run_test 'rpcd exec bridge list output is valid JSON' test_rpcd_bridge_list_output_valid_json
 run_test 'rpcd exec bridge dispatches json-status' test_rpcd_bridge_dispatches_json_status
 run_test 'rpcd exec bridge validates service actions' test_rpcd_bridge_service_control_validates_action
 run_test 'rpcd exec bridge passes install params' test_rpcd_bridge_install_passes_params
 run_test 'rpcd exec bridge reports async task status' test_rpcd_bridge_reports_task_status
 run_test 'rpcd exec bridge keeps multiline output valid JSON' test_rpcd_bridge_multiline_output_stays_valid_json
-run_test 'LuCI JS uses the new rpc object name' test_luci_js_uses_correct_rpc_object
-run_test 'LuCI config hides duplicate service toggle' test_luci_config_hides_service_toggle
-run_test 'LuCI maintenance distinguishes up-to-date scripts' test_luci_maintenance_handles_up_to_date_scripts
-run_test 'LuCI URLs in manager match repo file paths' test_luci_urls_match_repo_paths
 run_test 'check_script_update skips when stdin is not a tty' test_check_script_update_skips_non_interactive
 run_test 'install_luci_app reports partial download failure' test_install_luci_app_reports_partial_failure
 run_test 'install_luci_app deploy rollback cleans first-install files' test_install_luci_app_deploy_rollback_first_install
 run_test 'install_luci_app deploy rollback restores old files on upgrade' test_install_luci_app_deploy_rollback_upgrade
 run_test 'uninstall removes overridden LuCI paths' test_uninstall_removes_overridden_luci_paths
-run_test 'library files exist in repository' test_library_files_exist_in_repo
 run_test 'all library functions are loadable via source' test_library_files_sourceable_independently
-run_test 'LIB_DIR override loads libraries from custom path' test_lib_dir_override_works
 run_test 'install_runtime_scripts installs all library files' test_install_runtime_scripts_installs_library_files
 run_test 'ensure_libraries bootstraps all runtime modules' test_ensure_libraries_bootstraps_all_modules
 run_test 'ensure_libraries repairs partial library sets' test_ensure_libraries_repairs_partial_library_sets
 run_test 'main exits when library bootstrap fails' test_main_fails_when_library_bootstrap_fails
 run_test 'json_escape handles special characters' test_json_escape_special_chars
-run_test 'json_kv and json_kv_raw produce correct output' test_json_kv_and_kv_raw
 run_test 'json_array_from_lines builds JSON arrays' test_json_array_from_lines
-run_test 'json-status returns not-installed state' test_json_status_not_installed
-run_test 'json-status not-installed produces valid JSON' test_json_status_not_installed_valid_json
+run_test 'json-status returns not-installed state with valid JSON' test_json_status_not_installed
 run_test 'json-install-info reports arch when not installed' test_json_install_info_reports_arch
 run_test 'json-install-info reports installed state' test_json_install_info_installed
 run_test 'json-latest-versions fetches both sources' test_json_latest_versions_both_sources
@@ -2302,6 +1981,5 @@ run_test 'all json-* commands produce valid JSON' test_json_output_valid
 run_test 'json-status parses tailscale status output' test_json_status_parses_tailscale_output
 run_test 'json-status keeps remote peers on jsonfilter backend' test_json_status_parses_remote_peers_with_jsonfilter_backend
 run_test '_get_display_name extracts names correctly' test_json_display_name_extraction
-run_test 'json-* subcommands are reachable from main' test_json_main_dispatch
 
 printf '1..%s\n' "$TEST_INDEX"

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -2,6 +2,33 @@
 # Core install, update, uninstall, status, and automation commands
 # Sourced by tailscale-manager entry script.
 
+# Shared post-install flow: deploy managed files, configure cron, enable and
+# start the service, then verify it came up.  Returns 1 if tailscaled fails
+# to start so callers can decide whether to abort or continue.
+_finalize_install() {
+    local auto_update="${1:-0}"
+
+    install_runtime_scripts || return 1
+    install_update_script || return 1
+    install_luci_app || return 1
+    if [ "$auto_update" = "1" ]; then
+        setup_cron
+    else
+        remove_cron
+    fi
+
+    "$INIT_SCRIPT" enable
+    "$INIT_SCRIPT" start
+
+    if wait_for_tailscaled 10; then
+        show_service_status
+        return 0
+    else
+        log_error "tailscaled failed to start. Check logs: cat /var/log/tailscale.log"
+        return 1
+    fi
+}
+
 do_install() {
     echo ""
     echo "============================================="
@@ -153,25 +180,9 @@ do_install() {
 
     create_uci_config "$storage_mode" "$bin_dir" "$DOWNLOAD_SOURCE" "$auto_update"
 
-    install_runtime_scripts || return 1
-    install_update_script || return 1
-    install_luci_app || return 1
-    if [ "$auto_update" = "1" ]; then
-        setup_cron
-    else
-        remove_cron
-    fi
-
     echo ""
     echo "Enabling and starting Tailscale service..."
-    "$INIT_SCRIPT" enable
-    "$INIT_SCRIPT" start
-
-    if wait_for_tailscaled 10; then
-        show_service_status
-    else
-        log_error "tailscaled failed to start. Check logs: cat /var/log/tailscale.log"
-    fi
+    _finalize_install "$auto_update" || return 1
 
     echo ""
     local configured_tun_mode
@@ -420,10 +431,10 @@ do_status() {
         else
             echo "  tailscaled: running"
         fi
-        if tailscaled_is_userspace; then
+        if is_tailscaled_userspace; then
             echo "  Active mode: userspace"
         else
-            echo "  Active mode: kernel"
+            echo "  Active mode: tun"
         fi
     else
         echo "  tailscaled: not running"
@@ -447,7 +458,7 @@ do_status() {
     echo ""
 }
 
-do_install_specific_version() {
+do_install_version() {
     echo ""
     echo "============================================="
     echo "  Install Specific Version"
@@ -594,26 +605,10 @@ do_install_specific_version() {
         mkdir -p "$STATE_DIR"
         create_uci_config "$storage_mode" "$bin_dir" "$DOWNLOAD_SOURCE" "$auto_update"
 
-        install_runtime_scripts || return 1
-        install_update_script || return 1
-        install_luci_app || return 1
-        if [ "$auto_update" = "1" ]; then
-            setup_cron
-        else
-            remove_cron
-        fi
-
         echo ""
         echo "Installation success!"
         echo "Starting service..."
-        "$INIT_SCRIPT" enable
-        "$INIT_SCRIPT" start
-
-        if wait_for_tailscaled 10; then
-            show_service_status
-        else
-            log_error "tailscaled failed to start. Check logs: cat /var/log/tailscale.log"
-        fi
+        _finalize_install "$auto_update" || return 1
     else
         echo "Installation failed."
         return 1
@@ -642,7 +637,7 @@ do_download_only() {
     download_tailscale "$version" "$arch" "$bin_dir"
 }
 
-do_install_quiet() {
+cmd_install() {
     local opt_source="" opt_storage="" opt_auto_update=""
 
     while [ $# -gt 0 ]; do
@@ -706,28 +701,11 @@ do_install_quiet() {
     mkdir -p "$STATE_DIR"
     create_uci_config "$storage_mode" "$bin_dir" "$DOWNLOAD_SOURCE" "$auto_update"
 
-    install_runtime_scripts || return 1
-    install_update_script || return 1
-    install_luci_app || return 1
-    if [ "$auto_update" = "1" ]; then
-        setup_cron
-    else
-        remove_cron
-    fi
-
-    "$INIT_SCRIPT" enable
-    "$INIT_SCRIPT" start
-
-    if wait_for_tailscaled 10; then
-        show_service_status
-        log_info "Installation complete"
-    else
-        log_error "tailscaled failed to start. Check logs: cat /var/log/tailscale.log"
-        return 1
-    fi
+    _finalize_install "$auto_update" || return 1
+    log_info "Installation complete"
 }
 
-do_install_version_quiet() {
+cmd_install_version() {
     local target_version="$1"
     shift || true
     local opt_source=""

--- a/usr/lib/tailscale/common.sh
+++ b/usr/lib/tailscale/common.sh
@@ -129,9 +129,10 @@ kernel_tun_available() {
 # ============================================================================
 
 # Determine effective TUN mode based on config and hardware
-# Args: $1 = requested mode (auto|kernel|userspace)
-# Output: "kernel" or "userspace"
-# Returns: 0 on success, 1 if kernel mode is required but unavailable
+# Args: $1 = requested mode (auto|tun|kernel|userspace)
+#        "kernel" is accepted for backward compatibility and treated as "tun".
+# Output: "tun" or "userspace"
+# Returns: 0 on success, 1 if TUN mode is required but unavailable
 get_effective_tun_mode() {
     local requested_mode="${1:-auto}"
 
@@ -140,13 +141,13 @@ get_effective_tun_mode() {
             echo "userspace"
             return 0
             ;;
-        kernel)
-            kernel_tun_available && echo "kernel"
+        tun|kernel)
+            kernel_tun_available && echo "tun"
             return $?
             ;;
         auto|"")
             if kernel_tun_available; then
-                echo "kernel"
+                echo "tun"
             else
                 echo "userspace"
             fi
@@ -154,7 +155,7 @@ get_effective_tun_mode() {
             ;;
         *)
             if kernel_tun_available; then
-                echo "kernel"
+                echo "tun"
             else
                 echo "userspace"
             fi

--- a/usr/lib/tailscale/deploy.sh
+++ b/usr/lib/tailscale/deploy.sh
@@ -11,6 +11,7 @@
 #   LUCI_ACL_URL, LUCI_ACL_DEST,
 #   CONFIG_TEMPLATE_URL, CONFIG_FILE,
 #   RAW_BASE_URL, LIB_DIR
+#   MODULE_LIBS (optional; defaults to the standard module set)
 #
 # Required functions:
 #   log_info(), log_error(), log_warn(), download_repo_file()
@@ -75,8 +76,9 @@ install_runtime_scripts() {
     install_common_lib || return 1
 
     local lib_base_url="${LIB_BASE_URL:-${RAW_BASE_URL}/usr/lib/tailscale}"
+    local module_libs="${MODULE_LIBS:-version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh}"
     local lib
-    for lib in version.sh download.sh firewall.sh deploy.sh selfupdate.sh commands.sh menu.sh json.sh; do
+    for lib in $module_libs; do
         download_repo_file "${lib_base_url}/${lib}" "${LIB_DIR}/${lib}" 644 || return 1
     done
 
@@ -85,93 +87,108 @@ install_runtime_scripts() {
 
 # Deploy LuCI app files with atomic staging and rollback
 install_luci_app() {
-    local f1="${LUCI_VIEW_DIR}/config.js"
-    local f2="${LUCI_VIEW_DIR}/status.js"
-    local f3="${LUCI_VIEW_DIR}/maintenance.js"
-    local f4="$LUCI_RPC_DEST"
-    local f5="$LUCI_MENU_DEST"
-    local f6="$LUCI_ACL_DEST"
     local stag=".staging.$$"
     local bak=".bak.$$"
-    local f
 
-    mkdir -p "$LUCI_VIEW_DIR" "$(dirname "$f4")" "$(dirname "$f5")" "$(dirname "$f6")"
+    # File list: "url|dest|mode" triples
+    local _luci_files="
+${LUCI_VIEW_BASE_URL}/config.js|${LUCI_VIEW_DIR}/config.js|644
+${LUCI_VIEW_BASE_URL}/status.js|${LUCI_VIEW_DIR}/status.js|644
+${LUCI_VIEW_BASE_URL}/maintenance.js|${LUCI_VIEW_DIR}/maintenance.js|644
+${LUCI_RPC_URL}|${LUCI_RPC_DEST}|755
+${LUCI_MENU_URL}|${LUCI_MENU_DEST}|644
+${LUCI_ACL_URL}|${LUCI_ACL_DEST}|644
+"
 
-    if ! download_repo_file "${LUCI_VIEW_BASE_URL}/config.js" "${f1}${stag}" 644; then
-        rm -f "${f1}${stag}"
+    # Collect destination paths for later loops
+    local _dests="" _first_url="" _first_dest=""
+    local _entry _url _dest _mode
+    for _entry in $_luci_files; do
+        [ -n "$_entry" ] || continue
+        _url="${_entry%%|*}"
+        _dest="${_entry#*|}" ; _dest="${_dest%%|*}"
+        _mode="${_entry##*|}"
+        if [ -z "$_first_dest" ]; then
+            _first_url="$_url"; _first_dest="$_dest"
+        fi
+        _dests="$_dests $_dest"
+    done
+
+    # Ensure parent directories exist
+    local _d
+    for _d in $_dests; do
+        mkdir -p "$(dirname "$_d")"
+    done
+
+    # Stage: download all files to staging paths
+    if ! download_repo_file "$_first_url" "${_first_dest}${stag}" 644; then
+        rm -f "${_first_dest}${stag}"
         log_warn "LuCI app not available yet, skipping"
         return 0
     fi
 
-    local failed=0
-    download_repo_file "${LUCI_VIEW_BASE_URL}/status.js" "${f2}${stag}" 644 || failed=1
-    download_repo_file "${LUCI_VIEW_BASE_URL}/maintenance.js" "${f3}${stag}" 644 || failed=1
-    download_repo_file "$LUCI_RPC_URL" "${f4}${stag}" 755 || failed=1
-    download_repo_file "$LUCI_MENU_URL"  "${f5}${stag}" 644 || failed=1
-    download_repo_file "$LUCI_ACL_URL"   "${f6}${stag}" 644 || failed=1
+    local _failed=0
+    for _entry in $_luci_files; do
+        [ -n "$_entry" ] || continue
+        _url="${_entry%%|*}"
+        _dest="${_entry#*|}" ; _dest="${_dest%%|*}"
+        _mode="${_entry##*|}"
+        [ "$_dest" = "$_first_dest" ] && continue
+        download_repo_file "$_url" "${_dest}${stag}" "$_mode" || _failed=1
+    done
 
-    if [ "$failed" = "1" ]; then
-        rm -f "${f1}${stag}" "${f2}${stag}" "${f3}${stag}" "${f4}${stag}" "${f5}${stag}" "${f6}${stag}"
+    if [ "$_failed" = "1" ]; then
+        for _d in $_dests; do rm -f "${_d}${stag}"; done
         log_error "LuCI app download incomplete: some files failed to fetch"
         return 1
     fi
 
-    for f in "$f1" "$f2" "$f3" "$f4" "$f5" "$f6"; do
-        if [ -e "$f" ] && [ ! -w "$f" ]; then
-            rm -f "${f1}${stag}" "${f2}${stag}" "${f3}${stag}" "${f4}${stag}" "${f5}${stag}" "${f6}${stag}"
-            log_error "LuCI pre-flight failed: ${f} is not writable"
+    # Pre-flight: check writability
+    for _d in $_dests; do
+        if [ -e "$_d" ] && [ ! -w "$_d" ]; then
+            for _d in $_dests; do rm -f "${_d}${stag}"; done
+            log_error "LuCI pre-flight failed: ${_d} is not writable"
             return 1
         fi
     done
 
-    for f in "$f1" "$f2" "$f3" "$f4" "$f5" "$f6"; do
-        if [ -f "$f" ] && ! cp -f "$f" "${f}${bak}" 2>/dev/null; then
-            rm -f "${f1}${bak}" "${f2}${bak}" "${f3}${bak}" "${f4}${bak}" "${f5}${bak}" "${f6}${bak}" \
-                  "${f1}${stag}" "${f2}${stag}" "${f3}${stag}" "${f4}${stag}" "${f5}${stag}" "${f6}${stag}"
-            log_error "LuCI backup failed for ${f}, aborting deploy"
+    # Backup existing files
+    for _d in $_dests; do
+        if [ -f "$_d" ] && ! cp -f "$_d" "${_d}${bak}" 2>/dev/null; then
+            for _d in $_dests; do rm -f "${_d}${stag}" "${_d}${bak}"; done
+            log_error "LuCI backup failed for ${_d}, aborting deploy"
             return 1
         fi
     done
 
-    local deployed=0
-    while true; do
-        mv -f "${f1}${stag}" "$f1" || break; deployed=1
-        mv -f "${f2}${stag}" "$f2" || break; deployed=2
-        mv -f "${f3}${stag}" "$f3" || break; deployed=3
-        mv -f "${f4}${stag}" "$f4" || break; deployed=4
-        mv -f "${f5}${stag}" "$f5" || break; deployed=5
-        mv -f "${f6}${stag}" "$f6" || break; deployed=6
-        break
+    # Deploy: atomically move staging files into place
+    local _deployed=""
+    local _deploy_ok=1
+    for _d in $_dests; do
+        if mv -f "${_d}${stag}" "$_d" 2>/dev/null; then
+            _deployed="$_deployed $_d"
+        else
+            _deploy_ok=0
+            break
+        fi
     done
 
-    if [ "$deployed" -lt 6 ]; then
-        log_error "LuCI deploy failed at step $((deployed + 1)), rolling back"
-        if [ "$deployed" -ge 1 ]; then
-            if [ -f "${f1}${bak}" ]; then mv -f "${f1}${bak}" "$f1" 2>/dev/null; else rm -f "$f1" 2>/dev/null; fi || true
-        fi
-        if [ "$deployed" -ge 2 ]; then
-            if [ -f "${f2}${bak}" ]; then mv -f "${f2}${bak}" "$f2" 2>/dev/null; else rm -f "$f2" 2>/dev/null; fi || true
-        fi
-        if [ "$deployed" -ge 3 ]; then
-            if [ -f "${f3}${bak}" ]; then mv -f "${f3}${bak}" "$f3" 2>/dev/null; else rm -f "$f3" 2>/dev/null; fi || true
-        fi
-        if [ "$deployed" -ge 4 ]; then
-            if [ -f "${f4}${bak}" ]; then mv -f "${f4}${bak}" "$f4" 2>/dev/null; else rm -f "$f4" 2>/dev/null; fi || true
-        fi
-        if [ "$deployed" -ge 5 ]; then
-            if [ -f "${f5}${bak}" ]; then mv -f "${f5}${bak}" "$f5" 2>/dev/null; else rm -f "$f5" 2>/dev/null; fi || true
-        fi
-        if [ "$deployed" -ge 6 ]; then
-            if [ -f "${f6}${bak}" ]; then mv -f "${f6}${bak}" "$f6" 2>/dev/null; else rm -f "$f6" 2>/dev/null; fi || true
-        fi
-        rm -f "${f1}${stag}" "${f2}${stag}" "${f3}${stag}" "${f4}${stag}" "${f5}${stag}" \
-              "${f6}${stag}" "${f1}${bak}" "${f2}${bak}" "${f3}${bak}" "${f4}${bak}" "${f5}${bak}" "${f6}${bak}"
+    if [ "$_deploy_ok" = "0" ]; then
+        log_error "LuCI deploy failed, rolling back"
+        for _d in $_deployed; do
+            if [ -f "${_d}${bak}" ]; then
+                mv -f "${_d}${bak}" "$_d" 2>/dev/null || true
+            else
+                rm -f "$_d" 2>/dev/null || true
+            fi
+        done
+        for _d in $_dests; do rm -f "${_d}${stag}" "${_d}${bak}"; done
         return 1
     fi
 
-    rm -f "${f1}${bak}" "${f2}${bak}" "${f3}${bak}" "${f4}${bak}" "${f5}${bak}" "${f6}${bak}"
+    # Cleanup backups and staging leftovers
+    for _d in $_dests; do rm -f "${_d}${bak}" "${_d}${stag}"; done
 
-    # Cleanup legacy ucode bridge on upgrade to exec-based rpcd bridge.
     rm -f /usr/share/rpcd/ucode/luci-tailscale.uc 2>/dev/null || true
 
     if [ -x /etc/init.d/rpcd ]; then

--- a/usr/lib/tailscale/deploy.sh
+++ b/usr/lib/tailscale/deploy.sh
@@ -189,6 +189,7 @@ ${LUCI_ACL_URL}|${LUCI_ACL_DEST}|644
     # Cleanup backups and staging leftovers
     for _d in $_dests; do rm -f "${_d}${bak}" "${_d}${stag}"; done
 
+    # Cleanup legacy ucode bridge on upgrade to exec-based rpcd bridge.
     rm -f /usr/share/rpcd/ucode/luci-tailscale.uc 2>/dev/null || true
 
     if [ -x /etc/init.d/rpcd ]; then

--- a/usr/lib/tailscale/json.sh
+++ b/usr/lib/tailscale/json.sh
@@ -30,14 +30,6 @@ json_escape() {
     }'
 }
 
-json_kv() {
-    printf '"%s":"%s"' "$1" "$(json_escape "$2")"
-}
-
-json_kv_raw() {
-    printf '"%s":%s' "$1" "$2"
-}
-
 json_array_from_lines() {
     local first=1
     printf '['
@@ -229,7 +221,7 @@ cmd_json_status() {
     local self_ips_json="[]" peers_json="[]"
 
     if [ "$running" = "true" ]; then
-        tun_mode="kernel"
+        tun_mode="tun"
         local cmdline=""
         cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) || cmdline=""
         case " $cmdline " in

--- a/usr/lib/tailscale/menu.sh
+++ b/usr/lib/tailscale/menu.sh
@@ -18,7 +18,7 @@ show_menu() {
     echo "  7) Setup Subnet Routing"
     echo "  8) Install Specific Version (Downgrade)"
     echo "  9) Auto-Update Settings"
-    echo " 10) Network Mode Settings"
+    echo " 10) TUN Mode Settings"
     echo ""
     echo "  0) Exit"
     echo ""
@@ -93,18 +93,18 @@ do_auto_update_settings() {
     fi
 }
 
-do_network_mode_settings() {
+do_tun_mode_settings() {
     echo ""
     echo "============================================="
-    echo "  Network Mode Settings"
+    echo "  TUN Mode Settings"
     echo "============================================="
     echo ""
     echo "Current: $(get_configured_tun_mode)"
     echo ""
     echo "  1) Auto"
-    echo "     - Prefer kernel TUN, fall back to userspace if unavailable"
-    echo "  2) Kernel"
-    echo "     - Require /dev/net/tun and normal kernel networking"
+    echo "     - Prefer TUN mode, fall back to userspace if unavailable"
+    echo "  2) TUN"
+    echo "     - Require /dev/net/tun device"
     echo "  3) Userspace"
     echo "     - Force userspace networking mode"
     echo ""
@@ -113,7 +113,7 @@ do_network_mode_settings() {
 
     case "$answer" in
         1) configure_tun_mode "auto" ;;
-        2) configure_tun_mode "kernel" ;;
+        2) configure_tun_mode "tun" ;;
         3)
             echo ""
             echo "  Proxy listen scope for userspace mode:"
@@ -145,9 +145,9 @@ interactive_menu() {
             5) do_status; printf "Press Enter to continue..."; read -r _ ;;
             6) do_view_logs ;;
             7) do_setup_subnet_routing; printf "Press Enter to continue..."; read -r _ ;;
-            8) do_install_specific_version; printf "Press Enter to continue..."; read -r _ ;;
+            8) do_install_version; printf "Press Enter to continue..."; read -r _ ;;
             9) do_auto_update_settings; printf "Press Enter to continue..."; read -r _ ;;
-            10) do_network_mode_settings; printf "Press Enter to continue..."; read -r _ ;;
+            10) do_tun_mode_settings; printf "Press Enter to continue..."; read -r _ ;;
             0) echo "Goodbye!"; exit 0 ;;
             *) echo "Invalid choice" ;;
         esac


### PR DESCRIPTION
## Summary
- unify the project around `tun_mode` terminology by switching user-facing and internal values from `kernel` to `tun`, aligning CLI, LuCI, status output, JSON output, and init/runtime behavior while keeping old config values working
- clean up the runtime script structure by centralizing the managed module list, simplifying LuCI deployment rollback logic, renaming non-interactive command handlers to `cmd_*`, and removing duplicated rpcd response formats
- reduce low-value test noise by moving static repository checks into lint, trimming redundant assertions, and keeping targeted regression coverage for install finalization, runtime bootstrap, tun-mode refresh, and JSON behavior

## Testing
- make test
- make lint