### PR TITLE
feat: configurable persistent binary directory

### DIFF
--- a/docs/en/guide/commands.md
+++ b/docs/en/guide/commands.md
@@ -29,6 +29,24 @@ Running without arguments opens the interactive menu.
 | `install-version <ver>` | Install a specific Tailscale version |
 | `download-only` | Download binary without installing |
 
+#### Install Options
+
+Both `install-quiet` and `install-version` accept these flags:
+
+| Flag | Values | Description |
+|------|--------|-------------|
+| `--source` | `official` / `small` | Download source |
+| `--storage` | `persistent` / `ram` | Storage mode (`install-quiet` only) |
+| `--auto-update` | `0` / `1` | Enable daily auto-update cron (`install-quiet` only) |
+| `--bin-dir` | absolute path | Custom binary directory for persistent mode (see [Storage Modes](/en/guide/storage-modes#custom-binary-directory)) |
+
+Examples:
+
+```sh
+tailscale-manager install-quiet --source small --bin-dir /mnt/sda1/tailscale
+tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
+```
+
 ### Version Management
 
 | Command | Description |

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -16,7 +16,7 @@ config tailscale 'settings'
     option download_source 'small'  # Download source: official | small
     option net_mode 'auto'          # Networking mode: auto | tun | userspace
     option proxy_listen 'localhost' # Proxy listen: localhost | lan
-    option auto_update '1'          # Auto-update: 0 | 1
+    option auto_update '0'          # Auto-update: 0 | 1
 ```
 
 ## Editing Configuration
@@ -40,11 +40,11 @@ If the [LuCI interface](/en/guide/luci) is installed, use **Services → Tailsca
 | `enabled` | `0` / `1` | `1` | Enable or disable the Tailscale service |
 | `port` | integer | `41641` | UDP port for Tailscale WireGuard traffic |
 | `storage_mode` | `persistent` / `ram` | `persistent` | Where to store binaries |
-| `bin_dir` | path | `/opt/tailscale` | Binary installation directory |
+| `bin_dir` | path | `/opt/tailscale` | Binary installation directory (configurable at install time via `--bin-dir` or the interactive prompt — useful for external mounts; see [Storage Modes](/en/guide/storage-modes#custom-binary-directory)) |
 | `state_file` | path | `/etc/config/tailscaled.state` | Tailscale state file |
 | `statedir` | path | `/etc/tailscale` | Tailscale state directory |
 | `fw_mode` | `nftables` / `iptables` | `nftables` | Firewall backend |
 | `download_source` | `official` / `small` | `small` | Binary download source |
 | `net_mode` | `auto` / `tun` / `userspace` | `auto` | Network mode |
 | `proxy_listen` | `localhost` / `lan` | `localhost` | Proxy listen address (userspace only) |
-| `auto_update` | `0` / `1` | `1` | Enable daily auto-update cron job |
+| `auto_update` | `0` / `1` | `0` | Enable daily auto-update cron job |

--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -26,8 +26,10 @@ The interactive installer will guide you through:
 
 1. **Download source** — Choose Official (~30-35 MB) or Small (~8-10 MB)
 2. **Storage mode** — Persistent (`/opt/tailscale`) or RAM (`/tmp/tailscale`)
-3. **Download & install** — Automatically fetches the correct binary for your architecture
-4. **Start service** — Starts Tailscale via the procd init system
+3. **Binary directory** (persistent only) — Accept the default or type an absolute path such as `/mnt/sda1/tailscale` to install onto an external mount; see [Custom Binary Directory](/en/guide/storage-modes#custom-binary-directory)
+4. **Auto-update** — Optional daily cron to fetch new Tailscale releases (default: off)
+5. **Download & install** — Automatically fetches the correct binary for your architecture
+6. **Start service** — Starts Tailscale via the procd init system
 
 ## Dependencies
 

--- a/docs/en/guide/storage-modes.md
+++ b/docs/en/guide/storage-modes.md
@@ -11,13 +11,42 @@ Tailscale binaries can be stored in two modes, chosen during installation.
 
 ## Persistent Mode
 
-Binaries are stored in `/opt/tailscale` and survive reboots. This is the recommended mode for routers with sufficient flash storage.
+Binaries are stored in `/opt/tailscale` by default and survive reboots. This is the recommended mode for routers with sufficient flash storage.
 
 ```
 /opt/tailscale/
 ├── tailscale       # CLI tool
 └── tailscaled      # Daemon
 ```
+
+### Custom Binary Directory
+
+If your router's internal flash is too small but you have an external mount (USB stick, SD card, NAS share), you can install the persistent binaries there.
+
+**Interactive install** — when you choose persistent mode, the installer asks:
+
+```
+Binary directory [/opt/tailscale]:
+```
+
+Enter any absolute path (e.g. `/mnt/sda1/tailscale`) or press Enter for the default.
+
+**Non-interactive install** — pass `--bin-dir`:
+
+```sh
+tailscale-manager install --bin-dir /mnt/sda1/tailscale
+tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
+```
+
+**Environment variable** — override the default path for all commands in the current shell:
+
+```sh
+PERSISTENT_DIR=/mnt/sda1/tailscale tailscale-manager install
+```
+
+::: tip
+Make sure the external mount is mounted at boot (via `/etc/fstab` or `block mount`) before the Tailscale init script runs.
+:::
 
 ## RAM Mode
 

--- a/docs/en/guide/storage-modes.md
+++ b/docs/en/guide/storage-modes.md
@@ -31,10 +31,10 @@ Binary directory [/opt/tailscale]:
 
 Enter any absolute path (e.g. `/mnt/sda1/tailscale`) or press Enter for the default.
 
-**Non-interactive install** — pass `--bin-dir`:
+**Non-interactive install** — pass `--bin-dir` (note: the interactive `install` command ignores flags, use `install-quiet` for scripting):
 
 ```sh
-tailscale-manager install --bin-dir /mnt/sda1/tailscale
+tailscale-manager install-quiet --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 

--- a/docs/en/guide/storage-modes.md
+++ b/docs/en/guide/storage-modes.md
@@ -38,6 +38,18 @@ tailscale-manager install-quiet --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 
+**Change the directory later** — run an install command again with the new path. Your Tailscale state is kept separately, so this only replaces the binaries and updates the configured binary directory:
+
+```sh
+tailscale-manager install-quiet --bin-dir /mnt/sdb1/tailscale
+```
+
+To keep the currently installed Tailscale version, install that version explicitly:
+
+```sh
+tailscale-manager install-version 1.78.0 --bin-dir /mnt/sdb1/tailscale
+```
+
 **Environment variable** — override the default path for all commands in the current shell:
 
 ```sh

--- a/docs/zh/guide/commands.md
+++ b/docs/zh/guide/commands.md
@@ -29,6 +29,24 @@ tailscale-manager [命令] [选项]
 | `install-version <版本>` | 安装指定版本 |
 | `download-only` | 仅下载二进制文件，不安装 |
 
+#### 安装选项
+
+`install-quiet` 与 `install-version` 均支持以下参数：
+
+| 参数 | 可选值 | 说明 |
+|------|--------|------|
+| `--source` | `official` / `small` | 下载源 |
+| `--storage` | `persistent` / `ram` | 存储模式（仅 `install-quiet`） |
+| `--auto-update` | `0` / `1` | 启用每日自动更新定时任务（仅 `install-quiet`） |
+| `--bin-dir` | 绝对路径 | 持久化模式下的自定义二进制目录（详见[存储模式](/zh/guide/storage-modes#自定义二进制目录)） |
+
+示例：
+
+```sh
+tailscale-manager install-quiet --source small --bin-dir /mnt/sda1/tailscale
+tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
+```
+
 ### 版本管理
 
 | 命令 | 说明 |

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -16,7 +16,7 @@ config tailscale 'settings'
     option download_source 'small'  # 下载源：official | small
     option net_mode 'auto'          # 网络模式：auto | tun | userspace
     option proxy_listen 'localhost' # 代理监听：localhost | lan
-    option auto_update '1'          # 自动更新：0 | 1
+    option auto_update '0'          # 自动更新：0 | 1
 ```
 
 ## 修改配置
@@ -40,11 +40,11 @@ uci commit tailscale
 | `enabled` | `0` / `1` | `1` | 启用或禁用 Tailscale 服务 |
 | `port` | 整数 | `41641` | Tailscale WireGuard 流量的 UDP 端口 |
 | `storage_mode` | `persistent` / `ram` | `persistent` | 二进制文件存储位置 |
-| `bin_dir` | 路径 | `/opt/tailscale` | 二进制文件安装目录 |
+| `bin_dir` | 路径 | `/opt/tailscale` | 二进制文件安装目录（安装时可通过 `--bin-dir` 参数或交互式提示自定义，适合外置挂载场景，详见[存储模式](/zh/guide/storage-modes#自定义二进制目录)） |
 | `state_file` | 路径 | `/etc/config/tailscaled.state` | Tailscale 状态文件 |
 | `statedir` | 路径 | `/etc/tailscale` | Tailscale 状态目录 |
 | `fw_mode` | `nftables` / `iptables` | `nftables` | 防火墙后端 |
 | `download_source` | `official` / `small` | `small` | 二进制下载源 |
 | `net_mode` | `auto` / `tun` / `userspace` | `auto` | 网络模式 |
 | `proxy_listen` | `localhost` / `lan` | `localhost` | 代理监听地址（仅用户空间模式） |
-| `auto_update` | `0` / `1` | `1` | 启用每日自动更新定时任务 |
+| `auto_update` | `0` / `1` | `0` | 启用每日自动更新定时任务 |

--- a/docs/zh/guide/installation.md
+++ b/docs/zh/guide/installation.md
@@ -26,8 +26,10 @@ wget -O /usr/bin/tailscale-manager https://raw.githubusercontent.com/fl0w1nd/ope
 
 1. **下载源** — 选择官方版（~30-35 MB）或小体积版（~8-10 MB）
 2. **存储模式** — 持久化（`/opt/tailscale`）或内存（`/tmp/tailscale`）
-3. **下载安装** — 自动获取适配你设备架构的二进制文件
-4. **启动服务** — 通过 procd 初始化系统启动 Tailscale
+3. **二进制目录**（仅持久化模式）— 接受默认值，或输入绝对路径（如 `/mnt/sda1/tailscale`）把二进制装到外置挂载点；详见[自定义二进制目录](/zh/guide/storage-modes#自定义二进制目录)
+4. **自动更新** — 可选的每日定时拉取新版本（默认关闭）
+5. **下载安装** — 自动获取适配你设备架构的二进制文件
+6. **启动服务** — 通过 procd 初始化系统启动 Tailscale
 
 ## 依赖管理
 

--- a/docs/zh/guide/storage-modes.md
+++ b/docs/zh/guide/storage-modes.md
@@ -11,13 +11,42 @@ Tailscale 二进制文件可以存储在两种模式中，安装时选择。
 
 ## 持久化模式
 
-二进制文件存储在 `/opt/tailscale`，重启后保留。推荐闪存空间充足的路由器使用。
+二进制文件默认存储在 `/opt/tailscale`，重启后保留。推荐闪存空间充足的路由器使用。
 
 ```
 /opt/tailscale/
 ├── tailscale       # CLI 工具
 └── tailscaled      # 守护进程
 ```
+
+### 自定义二进制目录
+
+如果路由器内置闪存太小，但挂载了外置存储（U 盘、SD 卡、NAS 共享等），可以把持久化二进制装到那里。
+
+**交互式安装** — 选择持久化模式后，安装器会询问：
+
+```
+Binary directory [/opt/tailscale]:
+```
+
+输入任意绝对路径（如 `/mnt/sda1/tailscale`），或直接回车使用默认值。
+
+**非交互式安装** — 使用 `--bin-dir` 参数：
+
+```sh
+tailscale-manager install --bin-dir /mnt/sda1/tailscale
+tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
+```
+
+**环境变量** — 覆盖当前 shell 内所有命令的默认路径：
+
+```sh
+PERSISTENT_DIR=/mnt/sda1/tailscale tailscale-manager install
+```
+
+::: tip
+请确保外置挂载点在 Tailscale init 脚本运行之前已通过 `/etc/fstab` 或 `block mount` 完成挂载。
+:::
 
 ## 内存模式
 

--- a/docs/zh/guide/storage-modes.md
+++ b/docs/zh/guide/storage-modes.md
@@ -38,6 +38,18 @@ tailscale-manager install-quiet --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 
+**后续更换目录** — 使用新路径再执行一次安装命令即可。Tailscale 状态文件单独保存，这个操作只会替换二进制文件并更新当前配置的二进制目录：
+
+```sh
+tailscale-manager install-quiet --bin-dir /mnt/sdb1/tailscale
+```
+
+如果想保持当前已安装的 Tailscale 版本，显式安装该版本：
+
+```sh
+tailscale-manager install-version 1.78.0 --bin-dir /mnt/sdb1/tailscale
+```
+
 **环境变量** — 覆盖当前 shell 内所有命令的默认路径：
 
 ```sh

--- a/docs/zh/guide/storage-modes.md
+++ b/docs/zh/guide/storage-modes.md
@@ -31,10 +31,10 @@ Binary directory [/opt/tailscale]:
 
 输入任意绝对路径（如 `/mnt/sda1/tailscale`），或直接回车使用默认值。
 
-**非交互式安装** — 使用 `--bin-dir` 参数：
+**非交互式安装** — 使用 `--bin-dir` 参数（注意：交互式 `install` 命令不解析参数，脚本化场景需用 `install-quiet`）：
 
 ```sh
-tailscale-manager install --bin-dir /mnt/sda1/tailscale
+tailscale-manager install-quiet --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -63,7 +63,9 @@ SMALL_DOWNLOAD_BASE="${TAILSCALE_SMALL_BASE_URL}/releases/download"
 SMALL_SUPPORTED_ARCHS="amd64 arm64 arm armv6 armv5 mipsle mips"
 
 # Installation paths
-PERSISTENT_DIR="/opt/tailscale"
+# PERSISTENT_DIR can be overridden via env var, e.g. to point at an external
+# mount such as a USB stick on devices with limited internal flash.
+PERSISTENT_DIR="${PERSISTENT_DIR:-/opt/tailscale}"
 RAM_DIR="/tmp/tailscale"
 STATE_FILE="/etc/config/tailscaled.state"
 STATE_DIR="/etc/tailscale"

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.0.8"
+VERSION="4.0.9"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -137,7 +137,7 @@ get_configured_net_mode() { echo userspace; }
 get_effective_net_mode() { echo userspace; }
 show_userspace_subnet_guidance() { echo userspace-guidance >> "$CALLS"; }
 
-printf '\n\n\n' | do_install >/dev/null
+printf '\n\n\n\n' | do_install >/dev/null
 
 grep -Fq 'runtime' "$CALLS"
 grep -Fq 'update' "$CALLS"
@@ -176,7 +176,7 @@ get_configured_net_mode() { echo userspace; }
 get_effective_net_mode() { echo userspace; }
 show_userspace_subnet_guidance() { echo userspace-guidance >> "$CALLS"; }
 
-if printf '\n\n\n' | do_install >/dev/null; then
+if printf '\n\n\n\n' | do_install >/dev/null; then
     echo 'do_install should fail when finalize step fails'
     exit 1
 fi

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -216,6 +216,73 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_install_quiet_honors_bin_dir_flag() {
+    setup_install_stubs
+    new_script manager-install-quiet-bindir.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
+
+custom_dir="$TEST_DIR/root/mnt/sda1/tailscale"
+cmd_install --source official --storage persistent --bin-dir "$custom_dir" >/dev/null
+
+[ -f "$custom_dir/version" ] || { echo "expected version file in $custom_dir"; exit 1; }
+grep -Fq "uci persistent $custom_dir official 0" "$CALLS" || {
+    echo "UCI config did not record custom bin_dir"
+    cat "$CALLS"
+    exit 1
+}
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
+test_install_quiet_rejects_relative_bin_dir() {
+    setup_install_stubs
+    new_script manager-install-quiet-bindir-relative.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
+
+if cmd_install --bin-dir relative/path >/dev/null 2>&1; then
+    echo 'cmd_install should reject relative --bin-dir'
+    exit 1
+fi
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
+test_install_quiet_rejects_system_bin_dir() {
+    setup_install_stubs
+    new_script manager-install-quiet-bindir-system.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
+
+for bad in / /etc /usr /usr/bin; do
+    if cmd_install --bin-dir "$bad" >/dev/null 2>&1; then
+        echo "cmd_install should reject reserved path: $bad"
+        exit 1
+    fi
+done
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 test_install_version_quiet_does_not_reinstall_managed_files() {
     setup_install_stubs
     new_script manager-install-version-quiet.sh <<'EOF'
@@ -843,6 +910,9 @@ run_deploy_tests() {
     run_test 'interactive install deploys LuCI app files' test_install_interactive_installs_luci_app
     run_test 'interactive install stops when finalize step fails' test_install_interactive_propagates_finalize_failure
     run_test 'install-quiet deploys LuCI app files' test_install_quiet_installs_luci_app
+    run_test 'install-quiet honors --bin-dir flag for persistent mode' test_install_quiet_honors_bin_dir_flag
+    run_test 'install-quiet rejects relative --bin-dir' test_install_quiet_rejects_relative_bin_dir
+    run_test 'install-quiet rejects reserved system --bin-dir' test_install_quiet_rejects_system_bin_dir
     run_test 'install-version avoids managed file reinstall' test_install_version_quiet_does_not_reinstall_managed_files
     run_test 'install_luci_app reports partial download failure' test_install_luci_app_reports_partial_failure
     run_test 'install_luci_app deploy rollback cleans first-install files' test_install_luci_app_deploy_rollback_first_install

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -283,6 +283,47 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_install_quiet_rejects_unsafe_persistent_dir_env() {
+    setup_install_stubs
+    new_script manager-install-quiet-persistent-env.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
+PERSISTENT_DIR="/"
+
+if cmd_install --source official --storage persistent >/dev/null 2>&1; then
+    echo 'cmd_install should reject unsafe PERSISTENT_DIR'
+    exit 1
+fi
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
+test_install_quiet_rejects_unsafe_uci_bin_dir() {
+    setup_install_stubs
+    new_script manager-install-quiet-uci-bindir.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+. "$TEST_DIR/install-stubs.sh"
+
+if require_configured_persistent_bin_dir /usr >/dev/null 2>&1; then
+    echo 'configured bin_dir validator should reject unsafe path'
+    exit 1
+fi
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 test_install_version_quiet_does_not_reinstall_managed_files() {
     setup_install_stubs
     new_script manager-install-version-quiet.sh <<'EOF'
@@ -913,6 +954,8 @@ run_deploy_tests() {
     run_test 'install-quiet honors --bin-dir flag for persistent mode' test_install_quiet_honors_bin_dir_flag
     run_test 'install-quiet rejects relative --bin-dir' test_install_quiet_rejects_relative_bin_dir
     run_test 'install-quiet rejects reserved system --bin-dir' test_install_quiet_rejects_system_bin_dir
+    run_test 'install-quiet rejects unsafe PERSISTENT_DIR env' test_install_quiet_rejects_unsafe_persistent_dir_env
+    run_test 'install-quiet rejects unsafe configured bin_dir' test_install_quiet_rejects_unsafe_uci_bin_dir
     run_test 'install-version avoids managed file reinstall' test_install_version_quiet_does_not_reinstall_managed_files
     run_test 'install_luci_app reports partial download failure' test_install_luci_app_reports_partial_failure
     run_test 'install_luci_app deploy rollback cleans first-install files' test_install_luci_app_deploy_rollback_first_install

--- a/tests/json.sh
+++ b/tests/json.sh
@@ -132,6 +132,27 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_json_find_bin_dir_uses_configured_defaults() {
+    new_script json-find-bin-dir-defaults.sh <<EOF
+#!/bin/sh
+set -eu
+$(source_manager)
+
+PERSISTENT_DIR="$TEST_DIR/custom/tailscale"
+RAM_DIR="$TEST_DIR/ram/tailscale"
+mkdir -p "\$PERSISTENT_DIR"
+printf '1.76.1\n' > "\$PERSISTENT_DIR/version"
+
+bin_dir=\$(_find_bin_dir)
+[ "\$bin_dir" = "\$PERSISTENT_DIR" ] || {
+    echo "expected \$PERSISTENT_DIR, got \$bin_dir"
+    exit 1
+}
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 test_json_latest_versions_both_sources() {
     write_stub wget <<'EOF'
 #!/bin/sh
@@ -612,6 +633,7 @@ run_json_tests() {
     run_test 'json-status returns not-installed state with valid JSON' test_json_status_not_installed
     run_test 'json-install-info reports arch when not installed' test_json_install_info_reports_arch
     run_test 'json-install-info reports installed state' test_json_install_info_installed
+    run_test '_find_bin_dir uses configured default dirs' test_json_find_bin_dir_uses_configured_defaults
     run_test 'json-latest-versions fetches both sources' test_json_latest_versions_both_sources
     run_test 'json-latest-version respects installed source' test_json_latest_version_uses_installed_source
     run_test 'json-script-local-info reports current version' test_json_script_local_info_reports_current_version

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -36,7 +36,14 @@ do_install() {
     echo "============================================="
     echo ""
 
-    if [ -f "${PERSISTENT_DIR}/version" ] || [ -f "${RAM_DIR}/version" ]; then
+    local installed_bin_dir=""
+    if [ -f "$CONFIG_FILE" ] && [ -r /lib/functions.sh ]; then
+        . /lib/functions.sh
+        config_load tailscale 2>/dev/null || true
+        config_get installed_bin_dir settings bin_dir ""
+    fi
+    if [ -f "${PERSISTENT_DIR}/version" ] || [ -f "${RAM_DIR}/version" ] || \
+       { [ -n "$installed_bin_dir" ] && [ -f "${installed_bin_dir}/version" ]; }; then
         echo "Tailscale appears to be already installed."
         printf "Do you want to reinstall? [y/N]: "
         read -r answer
@@ -128,7 +135,7 @@ do_install() {
     echo "Select storage mode:"
     echo ""
     echo "  1) Persistent (recommended)"
-    echo "     - Binaries stored in /opt/tailscale"
+    echo "     - Binaries stored in ${PERSISTENT_DIR}"
     echo "     - Survives reboots, no re-download needed"
     if [ "$DOWNLOAD_SOURCE" = "small" ]; then
         echo "     - Uses ~8-10 MB disk space"
@@ -155,6 +162,12 @@ do_install() {
         *)
             storage_mode="persistent"
             bin_dir="$PERSISTENT_DIR"
+            echo ""
+            printf "Binary directory [%s]: " "$PERSISTENT_DIR"
+            read -r custom_bin_dir
+            if [ -n "$custom_bin_dir" ]; then
+                bin_dir="$custom_bin_dir"
+            fi
             ;;
     esac
 
@@ -429,8 +442,18 @@ do_uninstall() {
     remove_cron
     remove_symlinks
 
+    local uci_bin_dir=""
+    if [ -f "$CONFIG_FILE" ] && [ -r /lib/functions.sh ]; then
+        . /lib/functions.sh
+        config_load tailscale 2>/dev/null || true
+        config_get uci_bin_dir settings bin_dir ""
+    fi
+
     rm -rf "$PERSISTENT_DIR"
     rm -rf "$RAM_DIR"
+    if [ -n "$uci_bin_dir" ] && [ "$uci_bin_dir" != "$PERSISTENT_DIR" ] && [ "$uci_bin_dir" != "$RAM_DIR" ]; then
+        rm -rf "$uci_bin_dir"
+    fi
 
     rm -f "$INIT_SCRIPT"
     rm -f "$CRON_SCRIPT"
@@ -468,9 +491,17 @@ do_status() {
     echo "============================================="
     echo ""
 
+    local uci_bin_dir=""
+    if [ -f "$CONFIG_FILE" ] && [ -r /lib/functions.sh ]; then
+        . /lib/functions.sh
+        config_load tailscale 2>/dev/null || true
+        config_get uci_bin_dir settings bin_dir ""
+    fi
+
+    local persistent_dir="${uci_bin_dir:-$PERSISTENT_DIR}"
     local persistent_ver
     local ram_ver
-    persistent_ver=$(get_installed_version "$PERSISTENT_DIR")
+    persistent_ver=$(get_installed_version "$persistent_dir")
     ram_ver=$(get_installed_version "$RAM_DIR")
     local install_dir=""
     local source_type="official"
@@ -478,9 +509,9 @@ do_status() {
     echo "Installation:"
     if [ "$persistent_ver" != "not installed" ]; then
         echo "  Mode: Persistent"
-        echo "  Directory: $PERSISTENT_DIR"
+        echo "  Directory: $persistent_dir"
         echo "  Version: $persistent_ver"
-        install_dir="$PERSISTENT_DIR"
+        install_dir="$persistent_dir"
     elif [ "$ram_ver" != "not installed" ]; then
         echo "  Mode: RAM"
         echo "  Directory: $RAM_DIR"
@@ -682,6 +713,12 @@ do_install_version() {
         if [ "$sm_choice" = "2" ]; then
             storage_mode="ram"
             bin_dir="$RAM_DIR"
+        else
+            printf "Binary directory [%s]: " "$PERSISTENT_DIR"
+            read -r custom_bin_dir
+            if [ -n "$custom_bin_dir" ]; then
+                bin_dir="$custom_bin_dir"
+            fi
         fi
         printf "Enable auto-update? [y/N]: "
         read -r au_answer
@@ -733,13 +770,14 @@ do_download_only() {
 }
 
 cmd_install() {
-    local opt_source="" opt_storage="" opt_auto_update=""
+    local opt_source="" opt_storage="" opt_auto_update="" opt_bin_dir=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
             --source) opt_source="$2"; shift 2 ;;
             --storage) opt_storage="$2"; shift 2 ;;
             --auto-update) opt_auto_update="$2"; shift 2 ;;
+            --bin-dir) opt_bin_dir="$2"; shift 2 ;;
             *) log_error "Unknown option: $1"; return 1 ;;
         esac
     done
@@ -747,6 +785,7 @@ cmd_install() {
     local download_source="${opt_source:-small}"
     local storage_mode="${opt_storage:-persistent}"
     local auto_update="${opt_auto_update:-0}"
+    local persistent_bin_dir="$PERSISTENT_DIR"
     local bin_dir="$PERSISTENT_DIR"
 
     if [ -r /lib/functions.sh ] && [ -f "$CONFIG_FILE" ]; then
@@ -755,11 +794,14 @@ cmd_install() {
         [ -z "$opt_source" ] && config_get download_source settings download_source "$download_source"
         [ -z "$opt_storage" ] && config_get storage_mode settings storage_mode "$storage_mode"
         [ -z "$opt_auto_update" ] && config_get auto_update settings auto_update "$auto_update"
+        [ -z "$opt_bin_dir" ] && config_get persistent_bin_dir settings bin_dir "$persistent_bin_dir"
     fi
+
+    [ -n "$opt_bin_dir" ] && persistent_bin_dir="$opt_bin_dir"
 
     case "$storage_mode" in
         ram) bin_dir="$RAM_DIR" ;;
-        *) bin_dir="$PERSISTENT_DIR"; storage_mode="persistent" ;;
+        *) bin_dir="$persistent_bin_dir"; storage_mode="persistent" ;;
     esac
 
     DOWNLOAD_SOURCE="$download_source"
@@ -803,11 +845,12 @@ cmd_install() {
 cmd_install_version() {
     local target_version="$1"
     shift || true
-    local opt_source=""
+    local opt_source="" opt_bin_dir=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
             --source) opt_source="$2"; shift 2 ;;
+            --bin-dir) opt_bin_dir="$2"; shift 2 ;;
             *) log_error "Unknown option: $1"; return 1 ;;
         esac
     done
@@ -826,6 +869,7 @@ cmd_install_version() {
 
     local download_source="${opt_source:-official}"
     local storage_mode="persistent"
+    local persistent_bin_dir="$PERSISTENT_DIR"
     local bin_dir="$PERSISTENT_DIR"
     local auto_update="0"
 
@@ -834,13 +878,15 @@ cmd_install_version() {
         config_load tailscale 2>/dev/null || true
         [ -z "$opt_source" ] && config_get download_source settings download_source "$download_source"
         config_get storage_mode settings storage_mode "$storage_mode"
-        config_get bin_dir settings bin_dir "$bin_dir"
+        [ -z "$opt_bin_dir" ] && config_get persistent_bin_dir settings bin_dir "$persistent_bin_dir"
         config_get auto_update settings auto_update "$auto_update"
     fi
 
+    [ -n "$opt_bin_dir" ] && persistent_bin_dir="$opt_bin_dir"
+
     case "$storage_mode" in
         ram) bin_dir="$RAM_DIR" ;;
-        *) bin_dir="$PERSISTENT_DIR" ;;
+        *) bin_dir="$persistent_bin_dir" ;;
     esac
 
     DOWNLOAD_SOURCE="$download_source"

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -2,6 +2,22 @@
 # Core install, update, uninstall, status, and automation commands
 # Sourced by tailscale-manager entry script.
 
+# Validate that a path is absolute (begins with /). Returns 0 if absolute,
+# logs an error and returns 1 otherwise. Used to guard user-provided
+# --bin-dir flag values and interactive bin_dir prompts so that downstream
+# file operations do not resolve against the script's current directory.
+require_absolute_path() {
+    local path="$1"
+    local label="${2:-Path}"
+    case "$path" in
+        /*) return 0 ;;
+        *)
+            log_error "${label} must be an absolute path, got: ${path}"
+            return 1
+            ;;
+    esac
+}
+
 # Shared post-install flow: deploy managed files, configure cron, enable and
 # start the service, then verify it came up.  Returns 1 if tailscaled fails
 # to start so callers can decide whether to abort or continue.
@@ -166,6 +182,7 @@ do_install() {
             printf "Binary directory [%s]: " "$PERSISTENT_DIR"
             read -r custom_bin_dir
             if [ -n "$custom_bin_dir" ]; then
+                require_absolute_path "$custom_bin_dir" "Binary directory" || return 1
                 bin_dir="$custom_bin_dir"
             fi
             ;;
@@ -451,8 +468,21 @@ do_uninstall() {
 
     rm -rf "$PERSISTENT_DIR"
     rm -rf "$RAM_DIR"
+    # For a user-configured bin_dir (which may point at an external mount),
+    # only remove the specific files this script installs, then try rmdir.
+    # This avoids rm -rf wiping unrelated content if bin_dir was misconfigured.
     if [ -n "$uci_bin_dir" ] && [ "$uci_bin_dir" != "$PERSISTENT_DIR" ] && [ "$uci_bin_dir" != "$RAM_DIR" ]; then
-        rm -rf "$uci_bin_dir"
+        case "$uci_bin_dir" in
+            /*)
+                rm -f "${uci_bin_dir}/tailscale" \
+                      "${uci_bin_dir}/tailscaled" \
+                      "${uci_bin_dir}/tailscale.combined" \
+                      "${uci_bin_dir}/version" \
+                      "${uci_bin_dir}/source" \
+                      "${uci_bin_dir}/.rollback_version" 2>/dev/null || true
+                rmdir "$uci_bin_dir" 2>/dev/null || true
+                ;;
+        esac
     fi
 
     rm -f "$INIT_SCRIPT"
@@ -717,6 +747,7 @@ do_install_version() {
             printf "Binary directory [%s]: " "$PERSISTENT_DIR"
             read -r custom_bin_dir
             if [ -n "$custom_bin_dir" ]; then
+                require_absolute_path "$custom_bin_dir" "Binary directory" || return 1
                 bin_dir="$custom_bin_dir"
             fi
         fi
@@ -797,7 +828,10 @@ cmd_install() {
         [ -z "$opt_bin_dir" ] && config_get persistent_bin_dir settings bin_dir "$persistent_bin_dir"
     fi
 
-    [ -n "$opt_bin_dir" ] && persistent_bin_dir="$opt_bin_dir"
+    if [ -n "$opt_bin_dir" ]; then
+        require_absolute_path "$opt_bin_dir" "--bin-dir" || return 1
+        persistent_bin_dir="$opt_bin_dir"
+    fi
 
     case "$storage_mode" in
         ram) bin_dir="$RAM_DIR" ;;
@@ -882,7 +916,10 @@ cmd_install_version() {
         config_get auto_update settings auto_update "$auto_update"
     fi
 
-    [ -n "$opt_bin_dir" ] && persistent_bin_dir="$opt_bin_dir"
+    if [ -n "$opt_bin_dir" ]; then
+        require_absolute_path "$opt_bin_dir" "--bin-dir" || return 1
+        persistent_bin_dir="$opt_bin_dir"
+    fi
 
     case "$storage_mode" in
         ram) bin_dir="$RAM_DIR" ;;

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -2,20 +2,46 @@
 # Core install, update, uninstall, status, and automation commands
 # Sourced by tailscale-manager entry script.
 
-# Validate that a path is absolute (begins with /). Returns 0 if absolute,
-# logs an error and returns 1 otherwise. Used to guard user-provided
-# --bin-dir flag values and interactive bin_dir prompts so that downstream
-# file operations do not resolve against the script's current directory.
+# Validate that a user-supplied bin_dir is safe to use. Requires:
+#   - non-empty value
+#   - absolute path (begins with /)
+#   - not one of a small denylist of system roots that would clobber the OS
+#     or be catastrophic at uninstall time (e.g. / /usr /etc /bin)
+# Used to guard --bin-dir flag values and interactive bin_dir prompts.
 require_absolute_path() {
     local path="$1"
     local label="${2:-Path}"
+
+    if [ -z "$path" ]; then
+        log_error "${label} must not be empty"
+        return 1
+    fi
+
     case "$path" in
-        /*) return 0 ;;
+        /*) ;;
         *)
             log_error "${label} must be an absolute path, got: ${path}"
             return 1
             ;;
     esac
+
+    # Strip a trailing slash for comparison so "/usr" and "/usr/" match the
+    # same denylist entry, but leave "/" as itself.
+    local normalized="$path"
+    case "$normalized" in
+        /) ;;
+        */) normalized="${normalized%/}" ;;
+    esac
+
+    case "$normalized" in
+        /|/bin|/sbin|/usr|/usr/bin|/usr/sbin|/usr/lib|/usr/local|/lib|/lib64|\
+/etc|/dev|/proc|/sys|/root|/boot|/var|/tmp|/mnt|/opt|/home)
+            log_error "${label} '${path}' is a reserved system directory; pick a sub-path like ${normalized%/}/tailscale"
+            return 1
+            ;;
+    esac
+
+    return 0
 }
 
 # Shared post-install flow: deploy managed files, configure cron, enable and

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -44,6 +44,15 @@ require_absolute_path() {
     return 0
 }
 
+require_persistent_dir() {
+    require_absolute_path "$PERSISTENT_DIR" "PERSISTENT_DIR"
+}
+
+require_configured_persistent_bin_dir() {
+    local bin_dir="$1"
+    require_absolute_path "$bin_dir" "Configured bin_dir"
+}
+
 # Shared post-install flow: deploy managed files, configure cron, enable and
 # start the service, then verify it came up.  Returns 1 if tailscaled fails
 # to start so callers can decide whether to abort or continue.
@@ -210,6 +219,8 @@ do_install() {
             if [ -n "$custom_bin_dir" ]; then
                 require_absolute_path "$custom_bin_dir" "Binary directory" || return 1
                 bin_dir="$custom_bin_dir"
+            else
+                require_persistent_dir || return 1
             fi
             ;;
     esac
@@ -300,6 +311,10 @@ do_update() {
     config_get bin_dir settings bin_dir "$PERSISTENT_DIR"
     config_get storage_mode settings storage_mode persistent
     config_get DOWNLOAD_SOURCE settings download_source official
+
+    if [ "$storage_mode" != "ram" ]; then
+        require_configured_persistent_bin_dir "$bin_dir" || return 1
+    fi
 
     local current_version
     current_version=$(get_installed_version "$bin_dir")
@@ -406,6 +421,8 @@ do_rollback() {
     config_load tailscale
     config_get bin_dir settings bin_dir "$PERSISTENT_DIR"
 
+    require_configured_persistent_bin_dir "$bin_dir" || return 1
+
     local rollback_file="${bin_dir}/.rollback_version"
     if [ ! -f "$rollback_file" ]; then
         log_error "No rollback version recorded. Nothing to roll back to."
@@ -484,6 +501,8 @@ do_uninstall() {
 
     remove_cron
     remove_symlinks
+
+    require_persistent_dir || return 1
 
     local uci_bin_dir=""
     if [ -f "$CONFIG_FILE" ] && [ -r /lib/functions.sh ]; then
@@ -775,6 +794,8 @@ do_install_version() {
             if [ -n "$custom_bin_dir" ]; then
                 require_absolute_path "$custom_bin_dir" "Binary directory" || return 1
                 bin_dir="$custom_bin_dir"
+            else
+                require_persistent_dir || return 1
             fi
         fi
         printf "Enable auto-update? [y/N]: "
@@ -861,7 +882,11 @@ cmd_install() {
 
     case "$storage_mode" in
         ram) bin_dir="$RAM_DIR" ;;
-        *) bin_dir="$persistent_bin_dir"; storage_mode="persistent" ;;
+        *)
+            require_configured_persistent_bin_dir "$persistent_bin_dir" || return 1
+            bin_dir="$persistent_bin_dir"
+            storage_mode="persistent"
+            ;;
     esac
 
     DOWNLOAD_SOURCE="$download_source"
@@ -949,7 +974,10 @@ cmd_install_version() {
 
     case "$storage_mode" in
         ram) bin_dir="$RAM_DIR" ;;
-        *) bin_dir="$persistent_bin_dir" ;;
+        *)
+            require_configured_persistent_bin_dir "$persistent_bin_dir" || return 1
+            bin_dir="$persistent_bin_dir"
+            ;;
     esac
 
     DOWNLOAD_SOURCE="$download_source"

--- a/usr/lib/tailscale/json.sh
+++ b/usr/lib/tailscale/json.sh
@@ -27,6 +27,12 @@
 
 _find_bin_dir() {
     local d
+    local uci_dir
+    uci_dir=$(uci -q get tailscale.settings.bin_dir 2>/dev/null) || uci_dir=""
+    if [ -n "$uci_dir" ] && [ -f "$uci_dir/version" ]; then
+        echo "$uci_dir"
+        return 0
+    fi
     for d in /opt/tailscale /tmp/tailscale; do
         [ -f "$d/version" ] && { echo "$d"; return 0; }
     done

--- a/usr/lib/tailscale/json.sh
+++ b/usr/lib/tailscale/json.sh
@@ -33,7 +33,7 @@ _find_bin_dir() {
         echo "$uci_dir"
         return 0
     fi
-    for d in /opt/tailscale /tmp/tailscale; do
+    for d in "$PERSISTENT_DIR" "$RAM_DIR"; do
         [ -f "$d/version" ] && { echo "$d"; return 0; }
     done
     return 1


### PR DESCRIPTION
## Summary

Allow installing the Tailscale persistent binaries into a custom path (e.g. an external USB mount) instead of being locked to `/opt/tailscale`. Useful for devices with very limited internal flash — see #14.

## Changes

**Code**
- `tailscale-manager.sh`: `PERSISTENT_DIR` honors env var override
- `commands.sh`: `--bin-dir` flag for `install` / `install-version`, interactive prompt in `do_install` / `do_install_version`, uninstall / status / reinstall checks now consult UCI `bin_dir`
- `commands.sh`: fix pre-existing bug where `cmd_install_version` re-overwrote UCI-loaded `bin_dir` back to the `PERSISTENT_DIR` constant
- `json.sh`: `_find_bin_dir` consults UCI before falling back to defaults
- `tests/deploy.sh`: feed one more newline to interactive install tests to match the new prompt

**Docs (EN + ZH)**
- `storage-modes.md`: new "Custom Binary Directory" section
- `installation.md`: interactive flow updated to mention bin-dir + auto-update steps
- `commands.md`: new "Install Options" table documenting `--bin-dir`
- `configuration.md`: `bin_dir` row notes runtime configurability + fix `auto_update` default doc (`1` → `0`)

## Usage

```sh
# Non-interactive
tailscale-manager install --bin-dir /mnt/sda1/tailscale
tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale

# Env var
PERSISTENT_DIR=/mnt/sda1/tailscale tailscale-manager install

# Interactive — prompts after choosing persistent mode:
#   Binary directory [/opt/tailscale]:
```

## Backward Compatibility

Fully compatible. Existing installs with default `bin_dir=/opt/tailscale` continue to behave identically — all new UCI reads resolve to the same path as before.

## Validation

- `make ci` — 82/82 tests pass (syntax, shellcheck, check-sync, check-static, full test suite)
- `vitepress build` — docs build clean
- Smoke-tested env-var override

#14