### PR TITLE
fix(arch): correct MIPS big-endian detection for Atheros/QCA routers

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,6 +2,14 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.0.12 (2026-06-01)
+
+- Fix MIPS big-endian routers (e.g. Atheros/QCA) being misdetected as little-endian, causing wrong binary download and crash on boot (#14)
+- Add `mipsel`/`mips64el` cases for `uname -m` (Linux already distinguishes endianness at the kernel level)
+- Introduce `get_openwrt_arch()` helper that reads `DISTRIB_ARCH` from `/etc/openwrt_release` (covers all OpenWrt versions and derivatives), then falls back to `/etc/apk/arch` and `/etc/opkg.conf`
+- Remove unreliable `hexdump -o` byte-order heuristic; default to big-endian when all detection methods fail
+- Add tests for MIPS endianness detection and OpenWrt arch source priority
+
 ## v4.0.11 (2026-05-30)
 
 - Remove cron-based auto-update for management scripts and LuCI; script/UI updates are now manual only (Tailscale binary auto-update is retained)

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,6 +2,14 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.0.12 (2026-06-01)
+
+- 修复 MIPS 大端路由器（如 Atheros/QCA）被误判为小端导致下载错误二进制、启动崩溃的问题 (#14)
+- 新增 `mipsel`/`mips64el` 的 `uname -m` 分支（Linux 内核已区分字节序）
+- 引入 `get_openwrt_arch()` 辅助函数，优先读取 `/etc/openwrt_release` 的 `DISTRIB_ARCH`（覆盖所有 OpenWrt 版本及衍生版），其次回退至 `/etc/apk/arch` 和 `/etc/opkg.conf`
+- 移除不可靠的 `hexdump -o` 字节序检测，所有检测方法均失败时默认大端
+- 新增 MIPS 字节序检测与 OpenWrt 架构源优先级的测试
+
 ## v4.0.11 (2026-05-30)
 
 - 移除管理脚本与 LuCI 的自动更新（cron）功能，脚本和界面更新改为仅手动触发；Tailscale 二进制自动更新保留

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -183,18 +183,19 @@ if [ -f "$COMMON_LIB_PATH" ]; then
     . "$COMMON_LIB_PATH"
 else
     get_openwrt_arch() {
+        local root="${1:-}"
         local arch=""
-        if [ -r /etc/openwrt_release ]; then
-            arch=$(grep -E '^DISTRIB_ARCH=' /etc/openwrt_release 2>/dev/null \
+        if [ -r "${root}/etc/openwrt_release" ]; then
+            arch=$(grep -E '^DISTRIB_ARCH=' "${root}/etc/openwrt_release" 2>/dev/null \
                 | head -n1 | cut -d= -f2- | tr -d "'\"")
         fi
-        if [ -z "$arch" ] && [ -r /etc/apk/arch ]; then
-            arch=$(head -n1 /etc/apk/arch 2>/dev/null)
+        if [ -z "$arch" ] && [ -r "${root}/etc/apk/arch" ]; then
+            arch=$(head -n1 "${root}/etc/apk/arch" 2>/dev/null)
         fi
-        if [ -z "$arch" ] && [ -r /etc/opkg.conf ]; then
-            arch=$(awk '/^arch[[:space:]]/ {
+        if [ -z "$arch" ] && [ -r "${root}/etc/opkg.conf" ]; then
+            arch=$(awk '/^[[:space:]]*arch[[:space:]]/ {
                 if ($2 != "all" && $2 != "noarch") { print $2; exit }
-            }' /etc/opkg.conf 2>/dev/null)
+            }' "${root}/etc/opkg.conf" 2>/dev/null)
         fi
         printf '%s' "$arch"
     }

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -182,6 +182,7 @@ if [ -f "$COMMON_LIB_PATH" ]; then
     # shellcheck source=/dev/null
     . "$COMMON_LIB_PATH"
 else
+    # shellcheck disable=SC2120
     get_openwrt_arch() {
         local root="${1:-}"
         local arch=""
@@ -232,6 +233,7 @@ else
                 result="mipsle"
                 ;;
             mips)
+                # shellcheck disable=SC2119
                 owrt_arch=$(get_openwrt_arch)
                 case "$owrt_arch" in
                     mipsel*) result="mipsle" ;;
@@ -251,6 +253,7 @@ else
                 result="mips64le"
                 ;;
             mips64)
+                # shellcheck disable=SC2119
                 owrt_arch=$(get_openwrt_arch)
                 case "$owrt_arch" in
                     mips64el*|mipsel*) result="mips64le" ;;

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.0.11"
+VERSION="4.0.12"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)
@@ -182,8 +182,25 @@ if [ -f "$COMMON_LIB_PATH" ]; then
     # shellcheck source=/dev/null
     . "$COMMON_LIB_PATH"
 else
+    get_openwrt_arch() {
+        local arch=""
+        if [ -r /etc/openwrt_release ]; then
+            arch=$(grep -E '^DISTRIB_ARCH=' /etc/openwrt_release 2>/dev/null \
+                | head -n1 | cut -d= -f2- | tr -d "'\"")
+        fi
+        if [ -z "$arch" ] && [ -r /etc/apk/arch ]; then
+            arch=$(head -n1 /etc/apk/arch 2>/dev/null)
+        fi
+        if [ -z "$arch" ] && [ -r /etc/opkg.conf ]; then
+            arch=$(awk '/^arch[[:space:]]/ {
+                if ($2 != "all" && $2 != "noarch") { print $2; exit }
+            }' /etc/opkg.conf 2>/dev/null)
+        fi
+        printf '%s' "$arch"
+    }
+
     get_arch() {
-        local arch
+        local arch owrt_arch
         local result=""
 
         arch=$(uname -m)
@@ -210,27 +227,43 @@ else
             armv5tel|armv5tejl|armv5l|armv5)
                 result="armv5"
                 ;;
+            mipsel)
+                result="mipsle"
+                ;;
             mips)
-                if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
-                    result="mipsle"
-                elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
-                    result="mips"
-                elif printf 'I' | hexdump -o 2>/dev/null | grep -q '0001'; then
-                    result="mipsle"
-                else
-                    result="mips"
-                fi
+                owrt_arch=$(get_openwrt_arch)
+                case "$owrt_arch" in
+                    mipsel*) result="mipsle" ;;
+                    mips_*)  result="mips" ;;
+                    *)
+                        if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
+                            result="mipsle"
+                        elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
+                            result="mips"
+                        else
+                            result="mips"
+                        fi
+                        ;;
+                esac
+                ;;
+            mips64el)
+                result="mips64le"
                 ;;
             mips64)
-                if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
-                    result="mips64le"
-                elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
-                    result="mips64"
-                elif printf 'I' | hexdump -o 2>/dev/null | grep -q '0001'; then
-                    result="mips64le"
-                else
-                    result="mips64"
-                fi
+                owrt_arch=$(get_openwrt_arch)
+                case "$owrt_arch" in
+                    mips64el*|mipsel*) result="mips64le" ;;
+                    mips64_*|mips_*)   result="mips64" ;;
+                    *)
+                        if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
+                            result="mips64le"
+                        elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
+                            result="mips64"
+                        else
+                            result="mips64"
+                        fi
+                        ;;
+                esac
                 ;;
             i686|i386)
                 result="386"

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -343,20 +343,7 @@ mkdir -p "\$ROOT/etc/apk" "\$ROOT/etc/opkg"
 
 # Reload with overridden file paths via a wrapper
 test_get_arch() {
-    local arch=""
-    if [ -r "\$ROOT/etc/openwrt_release" ]; then
-        arch=\$(grep -E '^DISTRIB_ARCH=' "\$ROOT/etc/openwrt_release" 2>/dev/null \\
-            | head -n1 | cut -d= -f2- | tr -d "'\"")
-    fi
-    if [ -z "\$arch" ] && [ -r "\$ROOT/etc/apk/arch" ]; then
-        arch=\$(head -n1 "\$ROOT/etc/apk/arch" 2>/dev/null)
-    fi
-    if [ -z "\$arch" ] && [ -r "\$ROOT/etc/opkg.conf" ]; then
-        arch=\$(awk '/^arch[[:space:]]/ {
-            if (\$2 != "all" && \$2 != "noarch") { print \$2; exit }
-        }' "\$ROOT/etc/opkg.conf" 2>/dev/null)
-    fi
-    printf '%s' "\$arch"
+    get_openwrt_arch "\$ROOT"
 }
 
 # --- Case 1: DISTRIB_ARCH wins over everything else ---

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -233,6 +233,161 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_get_arch_mips_endianness() {
+    # Verify get_arch() picks BE vs LE correctly across all supported sources:
+    # DISTRIB_ARCH (universal), /etc/apk/arch (25.12+), /proc/cpuinfo, default.
+    new_script arch-detect.sh <<EOF
+#!/bin/sh
+set -eu
+. "$REPO_ROOT/usr/lib/tailscale/common.sh"
+
+# Helper: run get_arch with a mocked uname and get_openwrt_arch
+check() {
+    label=\$1
+    expected=\$2
+    actual=\$3
+    if [ "\$actual" != "\$expected" ]; then
+        printf 'FAIL: %s — expected %s, got %s\n' "\$label" "\$expected" "\$actual" >&2
+        exit 1
+    fi
+}
+
+# Stub uname to return "mips" or "mips64"
+uname() { echo "\$UNAME_M"; }
+
+# --- Case 1: DISTRIB_ARCH = mips_24kc (BE) ---
+get_openwrt_arch() { echo mips_24kc; }
+UNAME_M=mips
+check 'BE mips_24kc → mips' mips "\$(get_arch)"
+
+# --- Case 2: DISTRIB_ARCH = mipsel_24kc (LE) ---
+get_openwrt_arch() { echo mipsel_24kc; }
+UNAME_M=mips
+check 'LE mipsel_24kc → mipsle' mipsle "\$(get_arch)"
+
+# --- Case 3: No DISTRIB_ARCH, no apk/opkg, cpuinfo says big endian ---
+get_openwrt_arch() { echo ""; }
+# Override grep so /proc/cpuinfo check matches "big endian"
+_real_grep=\$(command -v grep)
+grep() {
+    case "\$*" in
+        *"little endian"*"/proc/cpuinfo"*) return 1 ;;
+        *"big endian"*"/proc/cpuinfo"*)    return 0 ;;
+        *) "\$_real_grep" "\$@" ;;
+    esac
+}
+UNAME_M=mips
+check 'cpuinfo big endian → mips' mips "\$(get_arch)"
+
+# --- Case 4: Same but cpuinfo says little endian ---
+grep() {
+    case "\$*" in
+        *"little endian"*"/proc/cpuinfo"*) return 0 ;;
+        *"big endian"*"/proc/cpuinfo"*)    return 1 ;;
+        *) "\$_real_grep" "\$@" ;;
+    esac
+}
+UNAME_M=mips
+check 'cpuinfo little endian → mipsle' mipsle "\$(get_arch)"
+
+# --- Case 5: All sources fail → default to mips (BE, the safer choice) ---
+grep() {
+    case "\$*" in
+        *"little endian"*"/proc/cpuinfo"*) return 1 ;;
+        *"big endian"*"/proc/cpuinfo"*)    return 1 ;;
+        *) "\$_real_grep" "\$@" ;;
+    esac
+}
+UNAME_M=mips
+check 'all sources fail → default mips' mips "\$(get_arch)"
+
+# --- Case 6: uname=mipsel always returns mipsle ---
+UNAME_M=mipsel
+check 'uname mipsel → mipsle' mipsle "\$(get_arch)"
+
+# --- Case 7: mips64 BE via DISTRIB_ARCH ---
+get_openwrt_arch() { echo mips64_octeonplus; }
+UNAME_M=mips64
+check 'BE mips64_* → mips64' mips64 "\$(get_arch)"
+
+# --- Case 8: mips64 LE via DISTRIB_ARCH ---
+get_openwrt_arch() { echo mips64el_octeonplus; }
+UNAME_M=mips64
+check 'LE mips64el_* → mips64le' mips64le "\$(get_arch)"
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
+test_get_openwrt_arch_sources() {
+    # Verify get_openwrt_arch() reads from each source in the right priority.
+    new_script openwrt-arch.sh <<EOF
+#!/bin/sh
+set -eu
+. "$REPO_ROOT/usr/lib/tailscale/common.sh"
+
+check() {
+    label=\$1
+    expected=\$2
+    actual=\$3
+    if [ "\$actual" != "\$expected" ]; then
+        printf 'FAIL: %s — expected "%s", got "%s"\n' "\$label" "\$expected" "\$actual" >&2
+        exit 1
+    fi
+}
+
+# Override file reads by redefining get_openwrt_arch inputs through a
+# wrapper that uses test-dir paths.
+ROOT="$TEST_DIR/root"
+mkdir -p "\$ROOT/etc/apk" "\$ROOT/etc/opkg"
+
+# Reload with overridden file paths via a wrapper
+test_get_arch() {
+    local arch=""
+    if [ -r "\$ROOT/etc/openwrt_release" ]; then
+        arch=\$(grep -E '^DISTRIB_ARCH=' "\$ROOT/etc/openwrt_release" 2>/dev/null \\
+            | head -n1 | cut -d= -f2- | tr -d "'\"")
+    fi
+    if [ -z "\$arch" ] && [ -r "\$ROOT/etc/apk/arch" ]; then
+        arch=\$(head -n1 "\$ROOT/etc/apk/arch" 2>/dev/null)
+    fi
+    if [ -z "\$arch" ] && [ -r "\$ROOT/etc/opkg.conf" ]; then
+        arch=\$(awk '/^arch[[:space:]]/ {
+            if (\$2 != "all" && \$2 != "noarch") { print \$2; exit }
+        }' "\$ROOT/etc/opkg.conf" 2>/dev/null)
+    fi
+    printf '%s' "\$arch"
+}
+
+# --- Case 1: DISTRIB_ARCH wins over everything else ---
+printf "DISTRIB_ARCH='mips_24kc'\n" > "\$ROOT/etc/openwrt_release"
+echo "x86_64" > "\$ROOT/etc/apk/arch"
+echo "arch wrong_arch 10" > "\$ROOT/etc/opkg.conf"
+check 'DISTRIB_ARCH wins' 'mips_24kc' "\$(test_get_arch)"
+
+# --- Case 2: Falls back to /etc/apk/arch when openwrt_release missing ---
+rm -f "\$ROOT/etc/openwrt_release"
+echo "mipsel_24kc" > "\$ROOT/etc/apk/arch"
+check '/etc/apk/arch fallback' 'mipsel_24kc' "\$(test_get_arch)"
+
+# --- Case 3: Falls back to /etc/opkg.conf when apk arch missing ---
+rm -f "\$ROOT/etc/apk/arch"
+cat > "\$ROOT/etc/opkg.conf" <<CONF
+dest root /
+arch all 100
+arch noarch 100
+arch mips_24kc 10
+CONF
+check '/etc/opkg.conf fallback (skip all/noarch)' 'mips_24kc' "\$(test_get_arch)"
+
+# --- Case 4: Nothing exists → empty string ---
+rm -f "\$ROOT/etc/opkg.conf"
+check 'no sources → empty' '' "\$(test_get_arch)"
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 run_common_tests() {
     run_test 'get_effective_net_mode falls back and fails correctly' test_effective_net_mode
     run_test 'net-mode refreshes runtime scripts before restart' test_net_mode_reinstalls_runtime_scripts
@@ -241,4 +396,6 @@ run_common_tests() {
     run_test 'migrate_config succeeds without uci command' test_migrate_config_no_uci_graceful
     run_test 'migrate_config succeeds without old tun_mode key' test_migrate_config_no_old_key
     run_test 'migrate_config is idempotent across multiple calls' test_migrate_config_idempotent
+    run_test 'get_arch picks correct MIPS endianness across all sources' test_get_arch_mips_endianness
+    run_test 'get_openwrt_arch reads sources in priority order' test_get_openwrt_arch_sources
 }

--- a/usr/lib/tailscale/common.sh
+++ b/usr/lib/tailscale/common.sh
@@ -13,6 +13,7 @@
 # x86_64, aarch64_cortex-a53). Tries multiple sources for compatibility
 # across OpenWrt versions (opkg-based <= 24.10, apk-based >= 25.12) and
 # downstream derivatives (iStoreOS, ImmortalWrt, ...).
+# shellcheck disable=SC2120
 get_openwrt_arch() {
     local root="${1:-}"
     local arch=""
@@ -77,6 +78,7 @@ get_arch() {
             # uname -m returns "mips" on some kernels for both BE and LE.
             # Prefer OpenWrt's own arch string (covers opkg & apk worlds),
             # then fall back to /proc/cpuinfo endian hints, then default to BE.
+            # shellcheck disable=SC2119
             owrt_arch=$(get_openwrt_arch)
             case "$owrt_arch" in
                 mipsel*) result="mipsle" ;;
@@ -100,6 +102,7 @@ get_arch() {
             ;;
         mips64)
             # Mirror the mips branch for 64-bit MIPS.
+            # shellcheck disable=SC2119
             owrt_arch=$(get_openwrt_arch)
             case "$owrt_arch" in
                 mips64el*|mipsel*) result="mips64le" ;;

--- a/usr/lib/tailscale/common.sh
+++ b/usr/lib/tailscale/common.sh
@@ -9,8 +9,38 @@
 # Architecture Detection
 # ============================================================================
 
+# Return the OpenWrt-style arch string (e.g. mips_24kc, mipsel_24kc,
+# x86_64, aarch64_cortex-a53). Tries multiple sources for compatibility
+# across OpenWrt versions (opkg-based <= 24.10, apk-based >= 25.12) and
+# downstream derivatives (iStoreOS, ImmortalWrt, ...).
+get_openwrt_arch() {
+    local arch=""
+
+    # 1. /etc/openwrt_release exists on every OpenWrt release and is
+    #    preserved by all known derivatives; this is the most universal source.
+    if [ -r /etc/openwrt_release ]; then
+        arch=$(grep -E '^DISTRIB_ARCH=' /etc/openwrt_release 2>/dev/null \
+            | head -n1 | cut -d= -f2- | tr -d "'\"")
+    fi
+
+    # 2. /etc/apk/arch on apk-based systems (snapshot/24.10+ snapshots, 25.12+)
+    if [ -z "$arch" ] && [ -r /etc/apk/arch ]; then
+        arch=$(head -n1 /etc/apk/arch 2>/dev/null)
+    fi
+
+    # 3. /etc/opkg.conf has lines like:  arch mipsel_24kc 10
+    #    Skip the universal "all" / "noarch" entries.
+    if [ -z "$arch" ] && [ -r /etc/opkg.conf ]; then
+        arch=$(awk '/^arch[[:space:]]/ {
+            if ($2 != "all" && $2 != "noarch") { print $2; exit }
+        }' /etc/opkg.conf 2>/dev/null)
+    fi
+
+    printf '%s' "$arch"
+}
+
 get_arch() {
-    local arch
+    local arch owrt_arch
     local result=""
 
     arch=$(uname -m)
@@ -38,29 +68,51 @@ get_arch() {
         armv5tel|armv5tejl|armv5l|armv5)
             result="armv5"
             ;;
+        mipsel)
+            # uname -m returns mipsel on little-endian MIPS Linux
+            result="mipsle"
+            ;;
         mips)
-            # Check endianness - try multiple methods for better compatibility
-            if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
-                result="mipsle"
-            elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
-                result="mips"
-            elif printf 'I' | hexdump -o 2>/dev/null | grep -q '0001'; then
-                result="mipsle"
-            else
-                result="mips"
-            fi
+            # uname -m returns "mips" on some kernels for both BE and LE.
+            # Prefer OpenWrt's own arch string (covers opkg & apk worlds),
+            # then fall back to /proc/cpuinfo endian hints, then default to BE.
+            owrt_arch=$(get_openwrt_arch)
+            case "$owrt_arch" in
+                mipsel*) result="mipsle" ;;
+                mips_*)  result="mips" ;;
+                *)
+                    if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
+                        result="mipsle"
+                    elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
+                        result="mips"
+                    else
+                        # Default to mips (BE): Atheros/QCA and most legacy
+                        # MIPS OpenWrt routers are big-endian.
+                        result="mips"
+                    fi
+                    ;;
+            esac
+            ;;
+        mips64el)
+            # uname -m returns mips64el on little-endian MIPS64 Linux
+            result="mips64le"
             ;;
         mips64)
-            # Check endianness - try multiple methods for better compatibility
-            if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
-                result="mips64le"
-            elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
-                result="mips64"
-            elif printf 'I' | hexdump -o 2>/dev/null | grep -q '0001'; then
-                result="mips64le"
-            else
-                result="mips64"
-            fi
+            # Mirror the mips branch for 64-bit MIPS.
+            owrt_arch=$(get_openwrt_arch)
+            case "$owrt_arch" in
+                mips64el*|mipsel*) result="mips64le" ;;
+                mips64_*|mips_*)   result="mips64" ;;
+                *)
+                    if grep -q "little endian" /proc/cpuinfo 2>/dev/null; then
+                        result="mips64le"
+                    elif grep -q "big endian" /proc/cpuinfo 2>/dev/null; then
+                        result="mips64"
+                    else
+                        result="mips64"
+                    fi
+                    ;;
+            esac
             ;;
         i686|i386)
             result="386"

--- a/usr/lib/tailscale/common.sh
+++ b/usr/lib/tailscale/common.sh
@@ -14,26 +14,27 @@
 # across OpenWrt versions (opkg-based <= 24.10, apk-based >= 25.12) and
 # downstream derivatives (iStoreOS, ImmortalWrt, ...).
 get_openwrt_arch() {
+    local root="${1:-}"
     local arch=""
 
     # 1. /etc/openwrt_release exists on every OpenWrt release and is
     #    preserved by all known derivatives; this is the most universal source.
-    if [ -r /etc/openwrt_release ]; then
-        arch=$(grep -E '^DISTRIB_ARCH=' /etc/openwrt_release 2>/dev/null \
+    if [ -r "${root}/etc/openwrt_release" ]; then
+        arch=$(grep -E '^DISTRIB_ARCH=' "${root}/etc/openwrt_release" 2>/dev/null \
             | head -n1 | cut -d= -f2- | tr -d "'\"")
     fi
 
     # 2. /etc/apk/arch on apk-based systems (snapshot/24.10+ snapshots, 25.12+)
-    if [ -z "$arch" ] && [ -r /etc/apk/arch ]; then
-        arch=$(head -n1 /etc/apk/arch 2>/dev/null)
+    if [ -z "$arch" ] && [ -r "${root}/etc/apk/arch" ]; then
+        arch=$(head -n1 "${root}/etc/apk/arch" 2>/dev/null)
     fi
 
     # 3. /etc/opkg.conf has lines like:  arch mipsel_24kc 10
     #    Skip the universal "all" / "noarch" entries.
-    if [ -z "$arch" ] && [ -r /etc/opkg.conf ]; then
-        arch=$(awk '/^arch[[:space:]]/ {
+    if [ -z "$arch" ] && [ -r "${root}/etc/opkg.conf" ]; then
+        arch=$(awk '/^[[:space:]]*arch[[:space:]]/ {
             if ($2 != "all" && $2 != "noarch") { print $2; exit }
-        }' /etc/opkg.conf 2>/dev/null)
+        }' "${root}/etc/opkg.conf" 2>/dev/null)
     fi
 
     printf '%s' "$arch"


### PR DESCRIPTION
## Problem

MIPS big-endian routers (e.g. TP-Link Archer C7 v5 with Atheros QCA956X, `mips_24kc`) were incorrectly detected as `mipsle` (little-endian), causing the wrong binary to be downloaded and an immediate crash on execution (`syntax error: unexpected "("`).

The root cause was twofold:

1. `uname -m` on Linux returns `mipsel` for LE and `mips` for BE, but the script only had a `mips)` case — there was no `mipsel)` branch to short-circuit the detection.
2. The `hexdump -o` byte-order heuristic was unreliable on BusyBox (OpenWrt's default userspace), producing false positives that misclassified BE systems as LE.

Ref: #14

## Changes

- **Add `mipsel`/`mips64el` cases** for `uname -m` — Linux already distinguishes endianness at the kernel level; when `uname -m` returns `mipsel` we can return `mipsle` directly.
- **Introduce `get_openwrt_arch()` helper** — reads the authoritative arch string from:
  1. `DISTRIB_ARCH` in `/etc/openwrt_release` (present on every OpenWrt release and all known derivatives — iStoreOS, ImmortalWrt, etc.)
  2. `/etc/apk/arch` (apk-based systems, OpenWrt 25.12+)
  3. `/etc/opkg.conf` (opkg-based systems, OpenWrt <= 24.10)
  
  Strings like `mips_24kc` (BE) vs `mipsel_24kc` (LE) are set by the OpenWrt build system and are far more reliable than runtime heuristics.
- **Remove unreliable `hexdump -o` heuristic** — default to big-endian (`mips`/`mips64`) when all detection methods fail, which is the safer choice since Atheros/QCA (the most common BE MIPS family in OpenWrt) is big-endian.
- **Add tests** for MIPS endianness detection (8 cases covering BE/LE across all sources) and OpenWrt arch source priority (4 cases covering fallback chain).
- **Bump version** to 4.0.12.

## Testing

All 87 tests pass (including 2 new test cases), `check-sync` and `make lint` are clean.

```
ok 8  - get_arch picks correct MIPS endianness across all sources
ok 9  - get_openwrt_arch reads sources in priority order
```