### PR TITLE
fix(download): parse small asset digest from compact GitHub API JSON

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.0.13 (2026-06-03)
+
+- Fix SHA-256 verification always failing for every small-source architecture except the alphabetically-last one (currently `mipsle`) (#14)
+- Root cause: `get_small_checksum()` assumed pretty-printed multi-line JSON, but GitHub's REST API returns compact single-line JSON; the sed range collapses to a single line and the greedy `.*` captures the last sha256 in the response (the alphabetically-last asset's digest)
+- Pre-split the response on `},{` asset boundaries so each asset lives on its own line, guaranteeing the digest belongs to the requested file
+- Add regression tests using a real compact GitHub API fixture covering first/middle/last/missing assets
+
 ## v4.0.12 (2026-06-01)
 
 - Fix MIPS big-endian routers (e.g. Atheros/QCA) being misdetected as little-endian, causing wrong binary download and crash on boot (#14)

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,6 +2,13 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.0.13 (2026-06-03)
+
+- 修复使用小体积下载源时，除字母序最末（当前为 `mipsle`）以外的架构 SHA-256 校验必然失败的问题 (#14)
+- 根因：`get_small_checksum()` 假设 GitHub API 返回多行 pretty-printed JSON，但实际为紧凑单行，sed 范围匹配退化后贪婪 `.*` 捕获到的是整行最后一个 sha256，即字母序末尾 asset 的 digest
+- 解析前先按 `},{` 边界拆分，使每个 asset 独占一行，确保抓到的就是目标文件的 digest
+- 新增针对真实紧凑 JSON 形态的回归测试，覆盖首/中/末/缺失等情况
+
 ## v4.0.12 (2026-06-01)
 
 - 修复 MIPS 大端路由器（如 Atheros/QCA）被误判为小端导致下载错误二进制、启动崩溃的问题 (#14)

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.0.12"
+VERSION="4.0.13"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)

--- a/tests/download.sh
+++ b/tests/download.sh
@@ -150,6 +150,60 @@ OUTER
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+# Regression for issue #14: GitHub REST API returns compact (single-line) JSON,
+# not the pretty-printed shape used by the previous fixture. With compact JSON
+# the greedy .* in the digest substitution used to capture the LAST sha256 in
+# the entire response (i.e. the asset listed last alphabetically) instead of
+# the one for the requested filename.
+test_get_small_checksum_parse_compact() {
+    new_script checksum-small-parse-compact.sh <<'OUTER'
+#!/bin/sh
+set -eu
+OUTER
+
+    cat >> "$LAST_SCRIPT" <<EOF
+$(source_manager)
+SMALL_RELEASES_API="file://"
+EOF
+
+    cat >> "$LAST_SCRIPT" <<'OUTER'
+# Real GitHub API shape: compact, no whitespace between fields, assets ordered
+# alphabetically with mipsle last (mirrors the v1.98.3 release exactly).
+cat > "$TEST_DIR/github-api.json" <<'APIJSON'
+{"tag_name":"v1.98.3","assets":[{"name":"tailscale-small_1.98.3_amd64.tgz","size":10654681,"digest":"sha256:e024c878c085ac6b54c6e3f3cf446184a3b6475a147657de83345d458ed1b02c"},{"name":"tailscale-small_1.98.3_arm.tgz","size":7945778,"digest":"sha256:0fa2d7628a8ea15a4470df5d963a125f9658532cf91741e9e40204f73bfefcca"},{"name":"tailscale-small_1.98.3_arm64.tgz","size":8641710,"digest":"sha256:ec1b35c7744fe0779328d25b43a2941b7f432e9d54c73e7ad705d816d9865d49"},{"name":"tailscale-small_1.98.3_mips.tgz","size":7744584,"digest":"sha256:7c12d950cfc3c1813de2d2e523437c53683398e28c8513e2d2578606a18674c2"},{"name":"tailscale-small_1.98.3_mipsle.tgz","size":7914233,"digest":"sha256:338d4794c3d57038da62eaefc6ed9f59489e56e8424ec3c68c27bad64e6f90c6"}]}
+APIJSON
+
+wget() {
+    cat "$TEST_DIR/github-api.json"
+}
+
+# Big-endian mips: the exact case from issue #14. Used to wrongly return the
+# mipsle digest because mipsle is alphabetically last.
+result=$(get_small_checksum "1.98.3" "tailscale-small_1.98.3_mips.tgz")
+[ "$result" = "7c12d950cfc3c1813de2d2e523437c53683398e28c8513e2d2578606a18674c2" ] || { echo "mips hash mismatch: $result"; exit 1; }
+
+# Last asset still parses correctly.
+result=$(get_small_checksum "1.98.3" "tailscale-small_1.98.3_mipsle.tgz")
+[ "$result" = "338d4794c3d57038da62eaefc6ed9f59489e56e8424ec3c68c27bad64e6f90c6" ] || { echo "mipsle hash mismatch: $result"; exit 1; }
+
+# A middle asset.
+result=$(get_small_checksum "1.98.3" "tailscale-small_1.98.3_arm.tgz")
+[ "$result" = "0fa2d7628a8ea15a4470df5d963a125f9658532cf91741e9e40204f73bfefcca" ] || { echo "arm hash mismatch: $result"; exit 1; }
+
+# First asset.
+result=$(get_small_checksum "1.98.3" "tailscale-small_1.98.3_amd64.tgz")
+[ "$result" = "e024c878c085ac6b54c6e3f3cf446184a3b6475a147657de83345d458ed1b02c" ] || { echo "amd64 hash mismatch: $result"; exit 1; }
+
+# Architecture not present in the release should fail.
+if get_small_checksum "1.98.3" "tailscale-small_1.98.3_mips64.tgz" 2>/dev/null; then
+    echo "missing arch should fail"
+    exit 1
+fi
+OUTER
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 test_verify_staged_binary_accepts_valid() {
     new_script verify-staged-ok.sh <<EOF
 #!/bin/sh
@@ -1006,6 +1060,7 @@ run_download_tests() {
     run_test 'verify_checksum skips when no tools available' test_verify_checksum_no_tools
     run_test 'get_official_checksum validates hex format' test_get_official_checksum_format
     run_test 'get_small_checksum parses GitHub API JSON' test_get_small_checksum_parse
+    run_test 'get_small_checksum parses compact (single-line) GitHub API JSON' test_get_small_checksum_parse_compact
     run_test 'verify_staged_binary accepts valid binary' test_verify_staged_binary_accepts_valid
     run_test 'verify_staged_binary rejects broken binary' test_verify_staged_binary_rejects_broken
     run_test 'verify_staged_binary prefers combined binary' test_verify_staged_binary_prefers_combined

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -85,9 +85,12 @@ get_small_checksum() {
     # substitution captures the *last* sha256 in the entire response (typically
     # the asset listed last alphabetically) instead of the one for the
     # requested file.
+    #
+    # awk is used for the boundary split because POSIX/BSD sed does not
+    # portably interpret \n in the replacement as a newline; awk's gsub does.
     digest=$(printf '%s' "$api_data" \
         | tr -d '\n' \
-        | sed -e 's/},[[:space:]]*{/}\n{/g' \
+        | awk '{gsub(/},[[:space:]]*{/, "}\n{"); print}' \
         | sed -n "/\"name\"[[:space:]]*:[[:space:]]*\"${filename_pattern}\"/{
             s/.*\"sha256:\([0-9a-f]*\)\".*/\1/p
             q

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -78,14 +78,20 @@ get_small_checksum() {
 
     filename_pattern=$(printf '%s\n' "$filename" | sed 's/[][\\/.*^$]/\\&/g')
 
-    # Extract digest for the matching asset using the exact asset name line.
-    # In pretty-printed JSON, "name" and "digest" are on separate lines within the same asset object.
-    digest=$(printf '%s\n' "$api_data" | sed -n "/\"name\"[[:space:]]*:[[:space:]]*\"${filename_pattern}\"/,/\"digest\"/{
-        /\"digest\"[[:space:]]*:[[:space:]]*\"sha256:/{
+    # GitHub's REST API returns compact single-line JSON. First strip all
+    # newlines so both compact and pretty-printed input become a single line,
+    # then re-introduce a newline only at asset object boundaries (},{) so each
+    # asset ends up on its own line. Without this, the greedy .* in the digest
+    # substitution captures the *last* sha256 in the entire response (typically
+    # the asset listed last alphabetically) instead of the one for the
+    # requested file.
+    digest=$(printf '%s' "$api_data" \
+        | tr -d '\n' \
+        | sed -e 's/},[[:space:]]*{/}\n{/g' \
+        | sed -n "/\"name\"[[:space:]]*:[[:space:]]*\"${filename_pattern}\"/{
             s/.*\"sha256:\([0-9a-f]*\)\".*/\1/p
             q
-        }
-    }")
+        }")
 
     if [ -z "$digest" ]; then
         return 1


### PR DESCRIPTION
## Summary

- Fix SHA-256 verification always failing for every small-source architecture except the alphabetically-last one (currently `mipsle`) — surfaced in #14.
- Root cause: `get_small_checksum()` assumed pretty-printed multi-line JSON, but GitHub's REST API returns compact single-line JSON. Once the sed range collapses to a single line, the greedy `.*` in `s/.*"sha256:\([0-9a-f]*\)".*/\1/` captures the **last** `sha256` in the entire response, i.e. the alphabetically-last asset's digest, not the one for the requested file.
- Concrete v1.98.3 repro: requesting `tailscale-small_1.98.3_mips.tgz` on a big-endian mips router downloads the correct file (`7c12d950...`), but the expected hash is wrongly computed as `mipsle`'s digest (`338d4794...`), so install is rejected as a checksum mismatch.

## Fix

In [usr/lib/tailscale/download.sh](usr/lib/tailscale/download.sh) `get_small_checksum()`:

1. `tr -d '\n'` collapses the response to a single line (no-op for compact JSON, flattens pretty-printed JSON).
2. `sed 's/},[[:space:]]*{/}\n{/g'` re-introduces a newline at every asset object boundary, so each asset ends up on its own line.
3. The downstream substitution can now only see one asset's `name` and `sha256`, so the greedy `.*` cannot bleed into the next asset.

Public behavior is unchanged — still returns a 64-char hex digest, or fails when the asset is absent.

## Tests

- New `tests/download.sh::test_get_small_checksum_parse_compact` uses a real-shape compact GitHub API fixture (mirrors v1.98.3 with 5 assets, `mipsle` last). It asserts:
  - Querying `mips` returns `mips`'s digest (precise regression for #14).
  - Querying `mipsle` still returns `mipsle`'s digest (last asset still works).
  - Querying `arm` / `amd64` returns their respective digests (middle / first asset).
  - Querying a missing `mips64` asset fails with non-zero status.
- Existing pretty-printed test `test_get_small_checksum_parse` is left intact, so both shapes are covered.
- Full suite passes locally: 88/88.

## Release notes

- `tailscale-manager.sh` `VERSION` 4.0.12 -> 4.0.13.
- `docs/zh/changelog.md` / `docs/en/changelog.md` get a new v4.0.13 entry at the top.

## Test plan

- [x] `sh tests/run.sh` on macOS — 88/88 passing.
- [ ] On the #14 reporter's hardware (TP-Link Archer C7 v5, mips_24kc big-endian): pull the new `tailscale-manager.sh`, run install with small source + mips, confirm checksum passes and the binary self-checks with `--version`.
- [ ] On a mipsle router: same flow, confirm no regression (mipsle was incidentally correct under the old implementation as the last asset).

Refs #14