### PR TITLE
fix(download): use char-class braces in awk regex for BusyBox compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,18 @@ jobs:
 
       - name: Run shell test suite
         run: TEST_SHELL=${{ matrix.shell }} make test
+
+  busybox-userspace-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run download tests with BusyBox userspace
+        run: |
+          docker run --rm -v "$PWD:/repo:ro" -w /repo busybox:1.38.0 sh -c '
+            busybox | head -1
+            echo "abc},{def" | awk "{gsub(/[}],[[:space:]]*[{]/, \"}\\n{\"); print}"
+            TEST_MODULE=download sh tests/run.sh
+          '

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,10 +2,14 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.0.14 (2026-06-03)
+
+- Fix v4.0.13 regressing `get_small_checksum()` on BusyBox awk: BusyBox treats `*{` as the start of a `{n,m}` interval expression and rejects the original `},[[:space:]]*{` regex with "Invalid contents of {}" / "Unmatched \{"; switch to character classes `[}],[[:space:]]*[{]` so braces are never parsed as interval delimiters
+
 ## v4.0.13 (2026-06-03)
 
-- Fix SHA-256 verification always failing for every small-source architecture except the alphabetically-last one (currently `mipsle`) (#14)
-- Root cause: `get_small_checksum()` assumed pretty-printed multi-line JSON, but GitHub's REST API returns compact single-line JSON; the sed range collapses to a single line and the greedy `.*` captures the last sha256 in the response (the alphabetically-last asset's digest)
+- Fix SHA-256 verification failing for every small-source architecture except the alphabetically-last one (currently `mipsle`) when the GitHub API response is delivered as compact single-line JSON (which happens on some networks / clients) (#14)
+- Root cause: `get_small_checksum()` assumed pretty-printed multi-line JSON; on a single-line input the sed range collapses and the greedy `.*` captures the last sha256 in the response (the alphabetically-last asset's digest)
 - Pre-split the response on `},{` asset boundaries so each asset lives on its own line, guaranteeing the digest belongs to the requested file
 - Add regression tests using a real compact GitHub API fixture covering first/middle/last/missing assets
 

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,10 +2,14 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.0.14 (2026-06-03)
+
+- 修复 v4.0.13 在 BusyBox awk 上 `get_small_checksum()` 直接报错并跳过校验的问题：BusyBox awk 把 `*{` 视为 `{n,m}` 区间量词起始，原正则 `},[[:space:]]*{` 触发 "Invalid contents of {}" / "Unmatched \{"；改用字符类 `[}],[[:space:]]*[{]` 规避
+
 ## v4.0.13 (2026-06-03)
 
-- 修复使用小体积下载源时，除字母序最末（当前为 `mipsle`）以外的架构 SHA-256 校验必然失败的问题 (#14)
-- 根因：`get_small_checksum()` 假设 GitHub API 返回多行 pretty-printed JSON，但实际为紧凑单行，sed 范围匹配退化后贪婪 `.*` 捕获到的是整行最后一个 sha256，即字母序末尾 asset 的 digest
+- 修复使用小体积下载源时，当 GitHub API 响应被压成紧凑单行 JSON 时（部分网络/客户端会出现），除字母序末尾架构（当前为 `mipsle`）以外的架构 SHA-256 校验必然失败的问题 (#14)
+- 根因：`get_small_checksum()` 假设 API 返回多行 pretty-printed JSON，sed 范围匹配在紧凑单行下退化后，贪婪 `.*` 捕获到的是整行最后一个 sha256，即字母序末尾 asset 的 digest
 - 解析前先按 `},{` 边界拆分，使每个 asset 独占一行，确保抓到的就是目标文件的 digest
 - 新增针对真实紧凑 JSON 形态的回归测试，覆盖首/中/末/缺失等情况
 

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.0.13"
+VERSION="4.0.14"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -78,19 +78,22 @@ get_small_checksum() {
 
     filename_pattern=$(printf '%s\n' "$filename" | sed 's/[][\\/.*^$]/\\&/g')
 
-    # GitHub's REST API returns compact single-line JSON. First strip all
-    # newlines so both compact and pretty-printed input become a single line,
-    # then re-introduce a newline only at asset object boundaries (},{) so each
-    # asset ends up on its own line. Without this, the greedy .* in the digest
-    # substitution captures the *last* sha256 in the entire response (typically
-    # the asset listed last alphabetically) instead of the one for the
-    # requested file.
+    # GitHub's REST API may return compact single-line JSON depending on the
+    # client / network path. First strip all newlines so both compact and
+    # pretty-printed input become a single line, then re-introduce a newline
+    # only at asset object boundaries (},{) so each asset ends up on its own
+    # line. Without this, the greedy .* in the digest substitution captures
+    # the *last* sha256 in the entire response (typically the asset listed
+    # last alphabetically) instead of the one for the requested file.
     #
     # awk is used for the boundary split because POSIX/BSD sed does not
     # portably interpret \n in the replacement as a newline; awk's gsub does.
+    # Braces are wrapped in character classes ([{] / [}]) because BusyBox awk
+    # otherwise reads `*{` as the start of a {n,m} interval expression and
+    # rejects the regex with "Invalid contents of {}".
     digest=$(printf '%s' "$api_data" \
         | tr -d '\n' \
-        | awk '{gsub(/},[[:space:]]*{/, "}\n{"); print}' \
+        | awk '{gsub(/[}],[[:space:]]*[{]/, "}\n{"); print}' \
         | sed -n "/\"name\"[[:space:]]*:[[:space:]]*\"${filename_pattern}\"/{
             s/.*\"sha256:\([0-9a-f]*\)\".*/\1/p
             q


### PR DESCRIPTION
## Summary

Follow-up to #17, reported by [@lutzapps](https://github.com/lutzapps) in [#14 (comment)](https://github.com/fl0w1nd/openwrt-tailscale/issues/14#issuecomment-4612570686).

After installing v4.0.13 on OpenWrt 25.12.2 (BusyBox v1.38), `get_small_checksum()` aborts before producing a digest:

```
[INFO] URL: https://github.com/fl0w1nd/openwrt-tailscale/releases/download/v1.98.3/tailscale-small_1.98.3_mips.tgz
awk: bad regex '},[[:space:]]*{': Invalid contents of {}
[WARN] Could not fetch checksum from GitHub API
```

## Root cause

BusyBox awk's regex parser is stricter than mawk / gawk / BSD awk: when it sees `*{` it tries to read `{n,m}` as an interval expression. The boundary regex `},[[:space:]]*{` introduced in #17 puts a literal `{` immediately after `*`, so BusyBox parses it as the start of a malformed interval and rejects the regex with `Invalid contents of {}` (some BusyBox builds also report `Unmatched \{`). The substitution never runs, no digest is extracted, and the surrounding code falls through to `[WARN] Could not fetch checksum from GitHub API` — leaving the install path unverified.

CI didn't catch this because `TEST_SHELL=busybox` only swaps the shell; `awk` resolves to whatever the host system provides (mawk on Ubuntu), which is more lenient than BusyBox awk.

## Fix

Wrap each literal brace in a character class so they are never parsed as interval delimiters:

```diff
-| awk '{gsub(/},[[:space:]]*{/, "}\n{"); print}' \
+| awk '{gsub(/[}],[[:space:]]*[{]/, "}\n{"); print}' \
```

Verified to behave identically across BusyBox awk v1.38, mawk, gawk, and BSD awk (macOS).

## Reproduction

Replicating issue #14's environment by collapsing the real GitHub API response to a single line and parsing under BusyBox awk:

```sh
docker run --rm busybox:latest sh -c '
  echo "abc},{def" | awk "{gsub(/},[[:space:]]*{/, \"}\\n{\"); print}"
  # awk: bad regex "},[[:space:]]*{": Invalid contents of {}
  echo "abc},{def" | awk "{gsub(/[}],[[:space:]]*[{]/, \"}\\n{\"); print}"
  # abc}
  # {def
'
```

End-to-end on the same compact-JSON fixture with BusyBox awk + sed, after the fix:

| arch    | digest |
|---------|--------|
| amd64   | `e024c878...` (correct) |
| arm     | `0fa2d762...` (correct) |
| arm64   | `ec1b35c7...` (correct) |
| armv5   | `c1a2595e...` (correct) |
| armv6   | `b40e2a0f...` (correct) |
| mips    | `7c12d950...` (correct, the issue #14 case) |
| mipsle  | `338d4794...` (correct) |

## Release

- `tailscale-manager.sh` `VERSION` 4.0.13 → 4.0.14.
- Changelog entry added at the top of `docs/{zh,en}/changelog.md`.

## Test plan

- [x] `sh tests/run.sh` on macOS — 88/88 passing.
- [x] BusyBox awk v1.38 in Docker — char-class regex accepted; all 7 archs return correct digests on a compact JSON fixture mirroring the user's environment.
- [ ] Issue #14 reporter on TP-Link Archer C7 v5 (mips_24kc, OpenWrt 25.12.2 + APK + BusyBox v1.38): pull v4.0.14, run `tailscale-manager` and select small + mips, confirm checksum verifies and binary self-checks with `--version`.

Refs #14