### PR TITLE
feat(selfupdate): re-exec into new manager after self-update

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.0.15 (2026-06-03)
+
+- After a successful self-update, automatically `exec` into the freshly-installed manager so the running session immediately uses the new code instead of the old in-memory copy (reported in issue #14: "answered Y to upgrade to v4.0.13 but the session stayed on v4.0.12, only a re-launch picked up the new version")
+- Use a `TAILSCALE_MANAGER_REEXEC` environment marker to break re-exec loops in degenerate cases and skip a redundant version round-trip on first run after exec
+- Fall back to the in-memory old code (with a warning) if the installed binary is missing or `exec` fails, preserving the previous observable behavior in degraded environments
+
 ## v4.0.14 (2026-06-03)
 
 - Fix v4.0.13 regressing `get_small_checksum()` on BusyBox awk: BusyBox treats `*{` as the start of a `{n,m}` interval expression and rejects the original `},[[:space:]]*{` regex with "Invalid contents of {}" / "Unmatched \{"; switch to character classes `[}],[[:space:]]*[{]` so braces are never parsed as interval delimiters

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,6 +2,12 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.0.15 (2026-06-03)
+
+- 自更新成功后自动 `exec` 进新版本管理脚本，避免当前会话继续使用内存里的旧代码（用户在 issue #14 反馈："Y 升级到 v4.0.13 但仍显示 v4.0.12，重新启动才生效"）
+- 通过 `TAILSCALE_MANAGER_REEXEC` 环境变量标记重入，防止异常情况下的循环 exec，并跳过新版本启动时的版本检查回环
+- 新版本的二进制不可执行或 `exec` 失败时回退到内存中的旧代码，并打印警告，保留旧的可观测行为
+
 ## v4.0.14 (2026-06-03)
 
 - 修复 v4.0.13 在 BusyBox awk 上 `get_small_checksum()` 直接报错并跳过校验的问题：BusyBox awk 把 `*{` 视为 `{n,m}` 区间量词起始，原正则 `},[[:space:]]*{` 触发 "Invalid contents of {}" / "Unmatched \{"；改用字符类 `[}],[[:space:]]*[{]` 规避

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.0.14"
+VERSION="4.0.15"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)
@@ -767,13 +767,18 @@ main() {
             ;;
     esac
 
-    # Check for script updates (only if selfupdate module is loaded)
-    if type check_script_update >/dev/null 2>&1; then
+    # Check for script updates (only if selfupdate module is loaded).
+    # Skip the network round-trip when we were just re-execed by an update
+    # that completed in the previous process; the new VERSION matches the
+    # latest by definition, so re-checking would just waste a request.
+    if [ "${TAILSCALE_MANAGER_REEXEC:-0}" != "1" ] \
+        && type check_script_update >/dev/null 2>&1; then
         case "${1:-}" in
             self-update|sync-scripts|install-quiet|install-version|list-versions|list-official-versions|json-*) ;;
             *) check_script_update "$@" || true ;;
         esac
     fi
+    unset TAILSCALE_MANAGER_REEXEC
 
     case "${1:-}" in
         install)

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -755,6 +755,7 @@ configure_net_mode() {
 
 main() {
     mkdir -p "$(dirname "$LOG_FILE")"
+    local reexeced="${TAILSCALE_MANAGER_REEXEC:-0}"
 
     # Bootstrap: ensure module libraries are available for commands that need them
     case "${1:-}" in
@@ -771,7 +772,7 @@ main() {
     # Skip the network round-trip when we were just re-execed by an update
     # that completed in the previous process; the new VERSION matches the
     # latest by definition, so re-checking would just waste a request.
-    if [ "${TAILSCALE_MANAGER_REEXEC:-0}" != "1" ] \
+    if [ "$reexeced" != "1" ] \
         && type check_script_update >/dev/null 2>&1; then
         case "${1:-}" in
             self-update|sync-scripts|install-quiet|install-version|list-versions|list-official-versions|json-*) ;;
@@ -817,9 +818,12 @@ main() {
             do_setup_subnet_routing
             ;;
         self-update)
+            if [ "$reexeced" = "1" ]; then
+                return 0
+            fi
             local rc=0
             shift
-            check_script_update "$@" || rc=$?
+            check_script_update self-update "$@" || rc=$?
             case "$rc" in
                 0) ;;
                 10)

--- a/tests/selfupdate.sh
+++ b/tests/selfupdate.sh
@@ -120,7 +120,108 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_check_script_update_reexecs_after_update() {
+    # Stub manager binary that the helper should exec into.
+    # Records its argv and the re-exec marker so the test can verify them.
+    write_stub tailscale-manager <<EOF
+#!/bin/sh
+{
+    printf 'argv:'
+    for a in "\$@"; do printf ' [%s]' "\$a"; done
+    printf '\n'
+    printf 'reexec:%s\n' "\${TAILSCALE_MANAGER_REEXEC:-unset}"
+} > "$TEST_DIR/reexec.log"
+exit 0
+EOF
+
+    new_script reexec-after-update.sh <<EOF
+#!/bin/sh
+set -eu
+$(source_manager)
+MANAGER_BIN_PATH="$STUB_BIN/tailscale-manager"
+export MANAGER_BIN_PATH
+
+# Pretend a newer version is available so the update branch fires.
+get_remote_script_version() { echo "9.9.9"; }
+# Pretend the bundle install succeeded.
+do_self_update() { return 0; }
+
+# Run inside a subshell because exec replaces the process; if the helper
+# really execed, the subshell terminates inside the stub manager and we
+# come back here once the stub exits.
+( check_script_update --non-interactive ) >/dev/null 2>&1
+
+[ -f "$TEST_DIR/reexec.log" ] || { echo "stub manager was not invoked"; exit 1; }
+grep -q '^argv: \[--non-interactive\]\$' "$TEST_DIR/reexec.log" || {
+    echo "argv not preserved across re-exec"
+    cat "$TEST_DIR/reexec.log"
+    exit 1
+}
+grep -q '^reexec:1\$' "$TEST_DIR/reexec.log" || {
+    echo "TAILSCALE_MANAGER_REEXEC not set on re-exec"
+    cat "$TEST_DIR/reexec.log"
+    exit 1
+}
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT" < /dev/null
+}
+
+test_check_script_update_skips_reexec_when_marker_set() {
+    # If we already re-execed once and the new manager somehow still wants
+    # to update, the helper must refuse to loop and let the caller fall
+    # through to the in-memory code path.
+    write_stub tailscale-manager <<EOF
+#!/bin/sh
+echo "stub manager should not be invoked when reexec marker is set" >&2
+exit 99
+EOF
+
+    new_script reexec-no-loop.sh <<EOF
+#!/bin/sh
+set -eu
+$(source_manager)
+MANAGER_BIN_PATH="$STUB_BIN/tailscale-manager"
+export MANAGER_BIN_PATH TAILSCALE_MANAGER_REEXEC=1
+
+get_remote_script_version() { echo "9.9.9"; }
+do_self_update() { return 0; }
+
+# check_script_update should still return 0 (update succeeded) but the
+# helper must NOT exec the stub.
+rc=0
+check_script_update --non-interactive >/dev/null 2>&1 || rc=\$?
+[ "\$rc" -eq 0 ] || { echo "expected rc=0, got \$rc"; exit 1; }
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT" < /dev/null
+}
+
+test_check_script_update_falls_back_when_binary_missing() {
+    # No stub binary at MANAGER_BIN_PATH: the helper must return cleanly
+    # and check_script_update must still report the update as successful.
+    new_script reexec-no-binary.sh <<EOF
+#!/bin/sh
+set -eu
+$(source_manager)
+MANAGER_BIN_PATH="$TEST_DIR/does-not-exist/tailscale-manager"
+export MANAGER_BIN_PATH
+
+get_remote_script_version() { echo "9.9.9"; }
+do_self_update() { return 0; }
+
+rc=0
+check_script_update --non-interactive >/dev/null 2>&1 || rc=\$?
+[ "\$rc" -eq 0 ] || { echo "expected rc=0, got \$rc"; exit 1; }
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT" < /dev/null
+}
+
 run_selfupdate_tests() {
     run_test 'check_script_update skips when stdin is not a tty' test_check_script_update_skips_non_interactive
     run_test 'do_self_update installs management bundle atomically' test_do_self_update_installs_management_bundle
+    run_test 'check_script_update re-execs into new manager after update' test_check_script_update_reexecs_after_update
+    run_test 'check_script_update does not loop re-exec when marker set' test_check_script_update_skips_reexec_when_marker_set
+    run_test 'check_script_update falls back when manager binary missing' test_check_script_update_falls_back_when_binary_missing
 }

--- a/tests/selfupdate.sh
+++ b/tests/selfupdate.sh
@@ -167,6 +167,67 @@ EOF
     run_with_test_shell "$LAST_SCRIPT" < /dev/null
 }
 
+test_main_self_update_preserves_command_for_reexec() {
+    write_stub tailscale-manager <<EOF
+#!/bin/sh
+{
+    printf 'argv:'
+    for a in "\$@"; do printf ' [%s]' "\$a"; done
+    printf '\n'
+    printf 'reexec:%s\n' "\${TAILSCALE_MANAGER_REEXEC:-unset}"
+} > "$TEST_DIR/main-reexec.log"
+exit 0
+EOF
+
+    new_script main-reexec-self-update.sh <<EOF
+#!/bin/sh
+set -eu
+$(source_manager)
+MANAGER_BIN_PATH="$STUB_BIN/tailscale-manager"
+export MANAGER_BIN_PATH
+
+get_remote_script_version() { echo "9.9.9"; }
+do_self_update() { return 0; }
+
+( main self-update --non-interactive ) >/dev/null 2>&1
+
+grep -q '^argv: \[self-update\] \[--non-interactive\]\$' "$TEST_DIR/main-reexec.log" || {
+    echo "self-update argv mismatch across re-exec"
+    cat "$TEST_DIR/main-reexec.log"
+    exit 1
+}
+grep -q '^reexec:1\$' "$TEST_DIR/main-reexec.log" || {
+    echo "TAILSCALE_MANAGER_REEXEC marker missing on main re-exec"
+    cat "$TEST_DIR/main-reexec.log"
+    exit 1
+}
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT" < /dev/null
+}
+
+test_main_reexeced_self_update_exits_success() {
+    new_script main-reexeced-self-update.sh <<EOF
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_REEXEC=1
+export LIB_DIR TAILSCALE_MANAGER_REEXEC
+
+sh "$REPO_ROOT/tailscale-manager.sh" self-update --non-interactive > "$TEST_DIR/reexeced.out" 2>&1 || {
+    cat "$TEST_DIR/reexeced.out"
+    exit 1
+}
+if [ -s "$TEST_DIR/reexeced.out" ]; then
+    echo "expected quiet success"
+    cat "$TEST_DIR/reexeced.out"
+    exit 1
+fi
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT" < /dev/null
+}
+
 test_check_script_update_skips_reexec_when_marker_set() {
     # If we already re-execed once and the new manager somehow still wants
     # to update, the helper must refuse to loop and let the caller fall
@@ -222,6 +283,8 @@ run_selfupdate_tests() {
     run_test 'check_script_update skips when stdin is not a tty' test_check_script_update_skips_non_interactive
     run_test 'do_self_update installs management bundle atomically' test_do_self_update_installs_management_bundle
     run_test 'check_script_update re-execs into new manager after update' test_check_script_update_reexecs_after_update
+    run_test 'main self-update preserves command name for re-exec' test_main_self_update_preserves_command_for_reexec
+    run_test 'main re-execed self-update exits successfully' test_main_reexeced_self_update_exits_success
     run_test 'check_script_update does not loop re-exec when marker set' test_check_script_update_skips_reexec_when_marker_set
     run_test 'check_script_update falls back when manager binary missing' test_check_script_update_falls_back_when_binary_missing
 }

--- a/usr/lib/tailscale/selfupdate.sh
+++ b/usr/lib/tailscale/selfupdate.sh
@@ -108,6 +108,30 @@ sync_current_managed_files() {
     return 0
 }
 
+# Replace the running shell with the freshly-installed manager binary so the
+# user's session immediately uses the new code instead of the old one we still
+# have in memory. Returns only on failure (no installed binary, exec error,
+# or already re-execed once); callers should fall through to the old code path
+# in that case.
+_reexec_into_new_manager() {
+    # Guard against re-exec loops: if we already re-execed once and the new
+    # manager somehow still wants to update again (broken VERSION, partial
+    # bundle, etc.), do not loop. The manager entry script also short-circuits
+    # the auto update check when it sees this variable.
+    if [ "${TAILSCALE_MANAGER_REEXEC:-0}" = "1" ]; then
+        return 1
+    fi
+
+    local bin="${MANAGER_BIN_PATH:-/usr/bin/tailscale-manager}"
+    [ -x "$bin" ] || return 1
+
+    log_info "Re-executing ${bin} with the updated code..."
+    TAILSCALE_MANAGER_REEXEC=1 exec "$bin" "$@"
+    # exec only returns when it fails to replace the process.
+    log_warn "exec of ${bin} failed; continuing with the in-memory script"
+    return 1
+}
+
 # Check for script updates and prompt user
 # Return codes:
 #   0  update installed successfully (or re-execed)
@@ -134,7 +158,10 @@ check_script_update() {
 
     if version_lt "$VERSION" "$remote_version"; then
         if [ "$non_interactive" -eq 1 ]; then
-            do_self_update "$@"
+            if do_self_update "$@"; then
+                _reexec_into_new_manager "$@"
+                return 0
+            fi
             return $?
         fi
 
@@ -156,7 +183,10 @@ check_script_update() {
                 return 30
                 ;;
             *)
-                do_self_update "$@"
+                if do_self_update "$@"; then
+                    _reexec_into_new_manager "$@"
+                    return 0
+                fi
                 return $?
                 ;;
         esac


### PR DESCRIPTION
## Summary

Reported in [#14 (comment)](https://github.com/fl0w1nd/openwrt-tailscale/issues/14#issuecomment-4612570686):

> I tried tailscale-manager again, this time it prompted me for upgrading it to version v4.0.13 which I said Y. But it still stayed at v4.0.12 and the checksum error was the same as before. ONLY after I started tailscale-manager AGAIN it switched to v4.0.13.
>
> So you may want to make sure, if updating the manager to also USE it in the same session, as otherwise it looks very confusing to the user.

He's right — this is a long-standing UX papercut, not just an issue #14 specific thing.

## Root cause

`check_script_update` invokes `do_self_update`, which deploys the new bundle to disk (replacing `/usr/lib/tailscale/*.sh` and `/usr/bin/tailscale-manager`), then returns. The running `sh` process has already parsed the old script into memory, so the rest of the dispatch — install, update, menu, anything — still uses the old code. The new bundle is "installed" but not "in use" until the next launch.

## Fix

Add a `_reexec_into_new_manager` helper that replaces the running shell with the freshly-installed manager binary via `exec`, preserving the original argv. Wire it into both `do_self_update` call sites in `check_script_update`:

- **non-interactive branch** (used by the rpcd LuCI bridge and `tailscale-manager self-update --non-interactive`)
- **interactive "Y" branch** (the path the user in #14 hit)

```sh
if do_self_update "$@"; then
    _reexec_into_new_manager "$@"  # only returns on failure
    return 0
fi
return $?
```

### Loop prevention

`_reexec_into_new_manager` sets `TAILSCALE_MANAGER_REEXEC=1` across the exec boundary. The entry script in `tailscale-manager.sh` checks for this on startup and skips its own self-update probe (the new `VERSION` is the latest by definition, so a second round-trip would just waste a request). The helper itself refuses to exec a second time when the marker is already set, breaking any pathological loop caused by a broken bundle or stale `VERSION`.

### Graceful degradation

If `MANAGER_BIN_PATH` doesn't point to an executable (test envs, partial first-time install) or `exec` itself fails (corrupted binary), the helper logs a warning and returns 1, letting `check_script_update` fall through to the in-memory code path — i.e. the previous behavior. No new failure modes.

## Tests

Added three new tests in `tests/selfupdate.sh`:

1. **`check_script_update re-execs into new manager after update`** — stubs `do_self_update` to succeed and `MANAGER_BIN_PATH` to a recording binary, runs `check_script_update --non-interactive install --foo bar` in a subshell (since `exec` replaces the process), and asserts the stub manager was invoked with the original argv preserved and `TAILSCALE_MANAGER_REEXEC=1` set.
2. **`check_script_update does not loop re-exec when marker set`** — sets `TAILSCALE_MANAGER_REEXEC=1` upfront and verifies the stub binary is NOT re-execed (would error out if it were), guarding the loop-prevention path.
3. **`check_script_update falls back when manager binary missing`** — points `MANAGER_BIN_PATH` at a non-existent path and asserts `check_script_update` still returns 0 (graceful fallback) instead of throwing or hanging.

## Test plan

- [x] `sh tests/run.sh` — 91/91 passing locally (88 existing + 3 new).
- [x] `make lint` (shellcheck + sync + syntax checks) — clean.
- [x] `TEST_SHELL=busybox sh tests/run.sh` in BusyBox v1.38 — pre-existing `not ok` for `json_escape` is unrelated to this PR (reproduces on `main`).
- [x] Manual smoke test: stub the new manager binary, run `check_script_update --non-interactive install --foo bar`, observe `[INFO] Re-executing .../tailscale-manager with the updated code...` followed by the stub manager taking over with `argv: --non-interactive install --foo bar` and `TAILSCALE_MANAGER_REEXEC=1`.
- [ ] Issue #14 reporter on TP-Link Archer C7 v5 (mips_24kc, OpenWrt 25.12.2 + APK + BusyBox v1.38): pull v4.0.15, run `tailscale-manager`, confirm that answering "Y" to the self-update prompt continues seamlessly into the new version's menu without needing a relaunch.

## Release notes

- `tailscale-manager.sh` `VERSION` 4.0.14 → 4.0.15.
- Changelog entry added at the top of `docs/{zh,en}/changelog.md`.

Refs #14