### PR TITLE
feat(init): inject custom procd env and tailscaled args via UCI

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.1.1 (2026-06-04)
+
+- Add UCI `list extra_env` and `list extra_args` to inject custom procd environment variables and `tailscaled` CLI arguments; entries are preserved across manager upgrades (#14)
+- Stop overwriting user-modified `port` / `net_mode` / `proxy_listen` / `update_cron` / `log_stdout` / `log_stderr` on reinstall; only install-time choices (`storage_mode`, `bin_dir`, `download_source`, `auto_update`) are still refreshed
+- Skip the default userspace `--socks5-server` / `--outbound-http-proxy-listen` flags when the same flag is supplied via `extra_args`, avoiding duplicate listener configuration
+- See [Configuration Reference](/en/guide/configuration#advanced-custom-env-and-cli-arguments) for usage
+
 ## v4.1.0 (2026-06-03)
 
 - Minor version bump consolidating the v4.0.12–v4.0.15 patch series (MIPS big-endian detection, small-source checksum parsing on compact JSON, BusyBox awk compatibility, self-update auto re-exec); no code changes beyond the `VERSION` field

--- a/docs/en/guide/configuration.md
+++ b/docs/en/guide/configuration.md
@@ -17,6 +17,11 @@ config tailscale 'settings'
     option net_mode 'auto'          # Networking mode: auto | tun | userspace
     option proxy_listen 'localhost' # Proxy listen: localhost | lan
     option auto_update '0'          # Auto-update: 0 | 1
+
+    # Advanced (optional): custom procd env vars and tailscaled CLI args.
+    # These list entries are preserved across manager upgrades.
+    list extra_env 'GOMIPS=softfloat'
+    list extra_args '--socks5-server=192.168.10.1:1080'
 ```
 
 ## Editing Configuration
@@ -48,3 +53,38 @@ If the [LuCI interface](/en/guide/luci) is installed, use **Services → Tailsca
 | `net_mode` | `auto` / `tun` / `userspace` | `auto` | Network mode |
 | `proxy_listen` | `localhost` / `lan` | `localhost` | Proxy listen address (userspace only) |
 | `auto_update` | `0` / `1` | `0` | Enable daily auto-update cron job |
+| `extra_env` | `list KEY=VALUE` | empty | Extra procd environment variables — see [Advanced: Custom env and CLI arguments](#advanced-custom-env-and-cli-arguments) below |
+| `extra_args` | `list --flag=...` | empty | Extra `tailscaled` command-line arguments — see [Advanced: Custom env and CLI arguments](#advanced-custom-env-and-cli-arguments) below |
+
+## Advanced: Custom env and CLI arguments
+
+`/etc/init.d/tailscale` is managed by `tailscale-manager` and gets overwritten on every upgrade, so **do not edit the init script directly**. Instead, use the `extra_env` / `extra_args` UCI lists — these entries are preserved across manager upgrades.
+
+### Typical use cases
+
+- **MIPS routers without FPU** (e.g. TP-Link Archer C7, `mips_24kc`): set `GOMIPS=softfloat` to avoid crashes from missing hardware floating-point
+- **Low-memory devices**: use `GOMEMLIMIT=24MiB` or `GODEBUG=asyncpreemptoff=1` to mitigate OOM
+- **Proxy services**: expose SOCKS5 / HTTP proxy to your LAN via `--socks5-server` / `--outbound-http-proxy-listen`
+
+### Example commands
+
+```sh
+# Inject environment variables
+uci add_list tailscale.settings.extra_env='GOMIPS=softfloat'
+uci add_list tailscale.settings.extra_env='GOMEMLIMIT=24MiB'
+
+# Inject tailscaled CLI arguments (each entry is a separate argument)
+uci add_list tailscale.settings.extra_args='--socks5-server=192.168.10.1:1080'
+uci add_list tailscale.settings.extra_args='--outbound-http-proxy-listen=192.168.10.1:1081'
+
+uci commit tailscale
+/etc/init.d/tailscale restart
+```
+
+### Notes
+
+- Each `extra_env` entry must be `KEY=VALUE` form and is passed verbatim to `procd_append_param env`
+- Each `extra_args` entry must be a single argument (long `=` options need not be split) and is appended in order to the end of the `tailscaled` command line
+- Neither list is escaped or validated — bad values will fail `tailscaled` startup; check `logread -e tailscale` to debug
+- In userspace mode the script normally injects `--socks5-server` / `--outbound-http-proxy-listen` on ports 1055/1056; supplying either flag via `extra_args` makes the script skip the corresponding default so only one listener is configured
+- If `TS_DEBUG_FIREWALL_MODE` is set via `extra_env`, the script skips its auto-detected `nftables`/`iptables` value so your override wins

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,6 +2,13 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.1.1 (2026-06-04)
+
+- 新增 UCI `list extra_env` 与 `list extra_args`，用于注入自定义 procd 环境变量与 `tailscaled` 启动参数，并在管理脚本升级时保留（#14）
+- 重装时不再覆盖用户改过的 `port` / `net_mode` / `proxy_listen` / `update_cron` / `log_stdout` / `log_stderr`；仅刷新安装期间用户主动选择的 `storage_mode` / `bin_dir` / `download_source` / `auto_update`
+- 当 `extra_args` 中已提供 `--socks5-server` 或 `--outbound-http-proxy-listen` 时，userspace 模式不再追加同名默认参数，避免出现重复 listener
+- 详细用法见[配置参考](/zh/guide/configuration#高级-自定义-env-和-cli-参数)
+
 ## v4.1.0 (2026-06-03)
 
 - 版本号晋升为 minor，归并 v4.0.12–v4.0.15 期间的修复（MIPS 大端检测、小体积源校验在紧凑 JSON 下的解析、BusyBox awk 兼容、自更新自动 re-exec），除 `VERSION` 字段外无代码改动

--- a/docs/zh/guide/configuration.md
+++ b/docs/zh/guide/configuration.md
@@ -17,6 +17,11 @@ config tailscale 'settings'
     option net_mode 'auto'          # 网络模式：auto | tun | userspace
     option proxy_listen 'localhost' # 代理监听：localhost | lan
     option auto_update '0'          # 自动更新：0 | 1
+
+    # 高级（可选）：自定义 procd 环境变量与 tailscaled 命令行参数
+    # 这些 list 项不会被脚本升级覆盖
+    list extra_env 'GOMIPS=softfloat'
+    list extra_args '--socks5-server=192.168.10.1:1080'
 ```
 
 ## 修改配置
@@ -48,3 +53,38 @@ uci commit tailscale
 | `net_mode` | `auto` / `tun` / `userspace` | `auto` | 网络模式 |
 | `proxy_listen` | `localhost` / `lan` | `localhost` | 代理监听地址（仅用户空间模式） |
 | `auto_update` | `0` / `1` | `0` | 启用每日自动更新定时任务 |
+| `extra_env` | `list KEY=VALUE` | 空 | 额外的 procd 环境变量，详见下方[高级：自定义 env 和 CLI 参数](#高级-自定义-env-和-cli-参数) |
+| `extra_args` | `list --flag=...` | 空 | 额外的 `tailscaled` 命令行参数，详见下方[高级：自定义 env 和 CLI 参数](#高级-自定义-env-和-cli-参数) |
+
+## 高级：自定义 env 和 CLI 参数
+
+`/etc/init.d/tailscale` 由 `tailscale-manager` 维护，每次升级都会被覆盖，因此**不要直接修改 init 脚本**。需要为 `tailscaled` 注入额外的环境变量或启动参数时，请通过 UCI 的 `extra_env` / `extra_args` list 实现，这些条目在脚本升级时会被保留。
+
+### 典型场景
+
+- **MIPS 软浮点路由器**（如 TP-Link Archer C7、mips_24kc）：设置 `GOMIPS=softfloat` 避免硬件 FPU 缺失导致崩溃
+- **低内存设备**：使用 `GOMEMLIMIT=24MiB` 或 `GODEBUG=asyncpreemptoff=1` 缓解 OOM
+- **代理服务**：通过 `--socks5-server` / `--outbound-http-proxy-listen` 暴露 SOCKS5 / HTTP 代理给局域网
+
+### 命令示例
+
+```sh
+# 注入环境变量
+uci add_list tailscale.settings.extra_env='GOMIPS=softfloat'
+uci add_list tailscale.settings.extra_env='GOMEMLIMIT=24MiB'
+
+# 注入 tailscaled 命令行参数（每项作为独立参数）
+uci add_list tailscale.settings.extra_args='--socks5-server=192.168.10.1:1080'
+uci add_list tailscale.settings.extra_args='--outbound-http-proxy-listen=192.168.10.1:1081'
+
+uci commit tailscale
+/etc/init.d/tailscale restart
+```
+
+### 说明
+
+- `extra_env` 的每一项必须是 `KEY=VALUE` 形式，原样传给 `procd_append_param env`
+- `extra_args` 的每一项必须是独立参数（含 `=` 的长选项无需拆分），按顺序追加到 `tailscaled` 命令尾部
+- 这两个选项不经任何转义或校验，错误的值会导致 `tailscaled` 启动失败；可用 `logread -e tailscale` 排查
+- 用户空间模式下脚本默认会注入 `--socks5-server` / `--outbound-http-proxy-listen`（端口 1055/1056）；若 `extra_args` 已包含其中之一，脚本会跳过对应默认值，避免出现重复的 listener
+- 若通过 `extra_env` 设置了 `TS_DEBUG_FIREWALL_MODE`，脚本会跳过自动检测的 `nftables`/`iptables`，保证你的覆盖生效

--- a/etc/config/tailscale
+++ b/etc/config/tailscale
@@ -12,3 +12,14 @@ config tailscale 'settings'
     option proxy_listen 'localhost'
     option log_stdout '1'
     option log_stderr '1'
+
+    # Advanced: extra environment variables passed to tailscaled via procd.
+    # Useful for low-end devices (e.g. MIPS without FPU) or Go runtime tuning.
+    # These are preserved across script upgrades.
+    # list extra_env 'GOMIPS=softfloat'
+    # list extra_env 'GOMEMLIMIT=24MiB'
+    # list extra_env 'GODEBUG=asyncpreemptoff=1'
+
+    # Advanced: extra command-line arguments appended to tailscaled.
+    # list extra_args '--socks5-server=192.168.10.1:1080'
+    # list extra_args '--outbound-http-proxy-listen=192.168.10.1:1081'

--- a/etc/init.d/tailscale
+++ b/etc/init.d/tailscale
@@ -10,6 +10,8 @@ STOP=1
 
 LOG_TAG="tailscale"
 LOG_FILE="/var/log/tailscale.log"
+EXTRA_ENV_KEYS=""
+EXTRA_ARG_FLAGS=""
 
 # ============================================================================
 # Logging
@@ -49,6 +51,11 @@ load_config() {
     config_get PROXY_LISTEN settings proxy_listen localhost
     config_get LOG_STDOUT settings log_stdout 1
     config_get LOG_STDERR settings log_stderr 1
+
+    EXTRA_ENV_KEYS=""
+    config_list_foreach settings extra_env remember_extra_env_key
+    EXTRA_ARG_FLAGS=""
+    config_list_foreach settings extra_args remember_extra_arg_flag
 }
 
 # ============================================================================
@@ -74,6 +81,61 @@ detect_ts_firewall_mode() {
 
 check_binary() {
     [ -x "${BIN_DIR}/tailscaled" ] || [ -x "${BIN_DIR}/tailscale.combined" ]
+}
+
+# config_list_foreach callbacks for user-defined extras
+remember_extra_env_key() {
+    local kv="$1"
+    local key
+    case "$kv" in
+        *=*)
+            key="${kv%%=*}"
+            [ -n "$key" ] && EXTRA_ENV_KEYS="${EXTRA_ENV_KEYS} ${key}"
+            ;;
+    esac
+}
+
+extra_env_has_key() {
+    local needle="$1"
+    local key
+    for key in $EXTRA_ENV_KEYS; do
+        [ "$key" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+# Record the flag name (text up to '=' or whole arg) so we can detect
+# duplicates between user-supplied extra_args and the script's own defaults.
+remember_extra_arg_flag() {
+    local arg="$1"
+    local flag
+    case "$arg" in
+        --*=*) flag="${arg%%=*}" ;;
+        --*) flag="$arg" ;;
+        *) return 0 ;;
+    esac
+    [ -n "$flag" ] && EXTRA_ARG_FLAGS="${EXTRA_ARG_FLAGS} ${flag}"
+}
+
+extra_args_has_flag() {
+    local needle="$1"
+    local flag
+    for flag in $EXTRA_ARG_FLAGS; do
+        [ "$flag" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+append_extra_env() {
+    local kv="$1"
+    [ -n "$kv" ] || return 0
+    procd_append_param env "$kv"
+}
+
+append_extra_arg() {
+    local arg="$1"
+    [ -n "$arg" ] || return 0
+    procd_append_param command "$arg"
 }
 
 # Download binaries for RAM mode
@@ -220,7 +282,11 @@ start_service() {
     # Start with procd
     procd_open_instance tailscale
     procd_set_param command "${BIN_DIR}/tailscaled"
-    procd_set_param env TS_DEBUG_FIREWALL_MODE="$FW_MODE"
+    if ! extra_env_has_key TS_DEBUG_FIREWALL_MODE; then
+        procd_set_param env TS_DEBUG_FIREWALL_MODE="$FW_MODE"
+    fi
+    # User-defined extra environment variables (UCI: list extra_env 'KEY=VAL')
+    config_list_foreach settings extra_env append_extra_env
     procd_append_param command --port "$PORT"
     procd_append_param command --state "$STATE_FILE"
     procd_append_param command --statedir "$STATE_DIR"
@@ -231,9 +297,15 @@ start_service() {
             lan|0.0.0.0) listen_addr="0.0.0.0" ;;
             *) listen_addr="localhost" ;;
         esac
-        procd_append_param command --socks5-server=${listen_addr}:1055
-        procd_append_param command --outbound-http-proxy-listen=${listen_addr}:1056
+        if ! extra_args_has_flag --socks5-server; then
+            procd_append_param command --socks5-server=${listen_addr}:1055
+        fi
+        if ! extra_args_has_flag --outbound-http-proxy-listen; then
+            procd_append_param command --outbound-http-proxy-listen=${listen_addr}:1056
+        fi
     fi
+    # User-defined extra command-line args (UCI: list extra_args '--flag=value')
+    config_list_foreach settings extra_args append_extra_arg
     procd_set_param respawn 3600 5 5
     procd_set_param stdout "$LOG_STDOUT"
     procd_set_param stderr "$LOG_STDERR"

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.1.0"
+VERSION="4.1.1"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -375,6 +375,197 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_init_extra_env_overrides_firewall_mode() {
+    new_script init-extra-env.sh <<'EOF'
+#!/bin/sh
+set -eu
+
+INIT_UNDER_TEST="$TEST_DIR/init-under-test.sh"
+sed 's#^\. /usr/lib/tailscale/common.sh$#:#' "$REPO_ROOT/etc/init.d/tailscale" > "$INIT_UNDER_TEST"
+. "$INIT_UNDER_TEST"
+LOG_FILE="$TEST_DIR/tailscale.log"
+
+CALLS="$TEST_DIR/procd.log"
+BIN_DIR_VALUE="$TEST_DIR/tailscale-bin"
+mkdir -p "$BIN_DIR_VALUE"
+cat > "$BIN_DIR_VALUE/tailscaled" <<'BIN'
+#!/bin/sh
+exit 0
+BIN
+chmod +x "$BIN_DIR_VALUE/tailscaled"
+
+migrate_config() { :; }
+config_load() { :; }
+config_get() {
+    var="$1"
+    option="$3"
+    default="${4:-}"
+    case "$option" in
+        bin_dir) value="$BIN_DIR_VALUE" ;;
+        state_file) value="$TEST_DIR/tailscaled.state" ;;
+        statedir) value="$TEST_DIR/state" ;;
+        *) value="$default" ;;
+    esac
+    eval "$var=\$value"
+}
+config_list_foreach() {
+    list="$2"
+    callback="$3"
+    case "$list" in
+        extra_env)
+            "$callback" 'TS_DEBUG_FIREWALL_MODE=nftables'
+            "$callback" 'GOMIPS=softfloat'
+            ;;
+        extra_args)
+            "$callback" '--socks5-server=192.168.10.1:1080'
+            ;;
+    esac
+}
+detect_ts_firewall_mode() { echo iptables; }
+wait_for_network() { return 0; }
+get_effective_net_mode() { echo tun; }
+procd_open_instance() { printf 'open %s\n' "$*" >> "$CALLS"; }
+procd_set_param() { printf 'set %s\n' "$*" >> "$CALLS"; }
+procd_append_param() { printf 'append %s\n' "$*" >> "$CALLS"; }
+procd_close_instance() { printf 'close\n' >> "$CALLS"; }
+
+start_service
+
+grep -Fq 'append env TS_DEBUG_FIREWALL_MODE=nftables' "$CALLS"
+grep -Fq 'append env GOMIPS=softfloat' "$CALLS"
+grep -Fq 'append command --socks5-server=192.168.10.1:1080' "$CALLS"
+if grep -Fq 'set env TS_DEBUG_FIREWALL_MODE=iptables' "$CALLS"; then
+    echo "detected firewall mode should yield to extra_env"
+    exit 1
+fi
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
+test_init_extra_args_overrides_userspace_defaults() {
+    new_script init-extra-args-userspace.sh <<'EOF'
+#!/bin/sh
+set -eu
+
+INIT_UNDER_TEST="$TEST_DIR/init-under-test.sh"
+sed 's#^\. /usr/lib/tailscale/common.sh$#:#' "$REPO_ROOT/etc/init.d/tailscale" > "$INIT_UNDER_TEST"
+. "$INIT_UNDER_TEST"
+LOG_FILE="$TEST_DIR/tailscale.log"
+
+CALLS="$TEST_DIR/procd.log"
+BIN_DIR_VALUE="$TEST_DIR/tailscale-bin"
+mkdir -p "$BIN_DIR_VALUE"
+cat > "$BIN_DIR_VALUE/tailscaled" <<'BIN'
+#!/bin/sh
+exit 0
+BIN
+chmod +x "$BIN_DIR_VALUE/tailscaled"
+
+migrate_config() { :; }
+config_load() { :; }
+config_get() {
+    var="$1"
+    option="$3"
+    default="${4:-}"
+    case "$option" in
+        bin_dir) value="$BIN_DIR_VALUE" ;;
+        state_file) value="$TEST_DIR/tailscaled.state" ;;
+        statedir) value="$TEST_DIR/state" ;;
+        net_mode) value="userspace" ;;
+        proxy_listen) value="localhost" ;;
+        *) value="$default" ;;
+    esac
+    eval "$var=\$value"
+}
+config_list_foreach() {
+    list="$2"
+    callback="$3"
+    case "$list" in
+        extra_args)
+            "$callback" '--socks5-server=192.168.10.1:1080'
+            "$callback" '--outbound-http-proxy-listen=192.168.10.1:1081'
+            ;;
+    esac
+}
+detect_ts_firewall_mode() { echo nftables; }
+wait_for_network() { return 0; }
+get_effective_net_mode() { echo userspace; }
+procd_open_instance() { printf 'open %s\n' "$*" >> "$CALLS"; }
+procd_set_param() { printf 'set %s\n' "$*" >> "$CALLS"; }
+procd_append_param() { printf 'append %s\n' "$*" >> "$CALLS"; }
+procd_close_instance() { printf 'close\n' >> "$CALLS"; }
+
+start_service
+
+grep -Fq 'append command --socks5-server=192.168.10.1:1080' "$CALLS"
+grep -Fq 'append command --outbound-http-proxy-listen=192.168.10.1:1081' "$CALLS"
+if grep -Fq 'append command --socks5-server=localhost:1055' "$CALLS"; then
+    echo "extra_args --socks5-server should suppress default localhost:1055"
+    exit 1
+fi
+if grep -Fq 'append command --outbound-http-proxy-listen=localhost:1056' "$CALLS"; then
+    echo "extra_args --outbound-http-proxy-listen should suppress default localhost:1056"
+    exit 1
+fi
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
+test_init_extra_args_userspace_defaults_remain_without_override() {
+    new_script init-extra-args-userspace-defaults.sh <<'EOF'
+#!/bin/sh
+set -eu
+
+INIT_UNDER_TEST="$TEST_DIR/init-under-test.sh"
+sed 's#^\. /usr/lib/tailscale/common.sh$#:#' "$REPO_ROOT/etc/init.d/tailscale" > "$INIT_UNDER_TEST"
+. "$INIT_UNDER_TEST"
+LOG_FILE="$TEST_DIR/tailscale.log"
+
+CALLS="$TEST_DIR/procd.log"
+BIN_DIR_VALUE="$TEST_DIR/tailscale-bin"
+mkdir -p "$BIN_DIR_VALUE"
+cat > "$BIN_DIR_VALUE/tailscaled" <<'BIN'
+#!/bin/sh
+exit 0
+BIN
+chmod +x "$BIN_DIR_VALUE/tailscaled"
+
+migrate_config() { :; }
+config_load() { :; }
+config_get() {
+    var="$1"
+    option="$3"
+    default="${4:-}"
+    case "$option" in
+        bin_dir) value="$BIN_DIR_VALUE" ;;
+        state_file) value="$TEST_DIR/tailscaled.state" ;;
+        statedir) value="$TEST_DIR/state" ;;
+        net_mode) value="userspace" ;;
+        proxy_listen) value="localhost" ;;
+        *) value="$default" ;;
+    esac
+    eval "$var=\$value"
+}
+config_list_foreach() { :; }
+detect_ts_firewall_mode() { echo nftables; }
+wait_for_network() { return 0; }
+get_effective_net_mode() { echo userspace; }
+procd_open_instance() { printf 'open %s\n' "$*" >> "$CALLS"; }
+procd_set_param() { printf 'set %s\n' "$*" >> "$CALLS"; }
+procd_append_param() { printf 'append %s\n' "$*" >> "$CALLS"; }
+procd_close_instance() { printf 'close\n' >> "$CALLS"; }
+
+start_service
+
+grep -Fq 'append command --socks5-server=localhost:1055' "$CALLS"
+grep -Fq 'append command --outbound-http-proxy-listen=localhost:1056' "$CALLS"
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 run_common_tests() {
     run_test 'get_effective_net_mode falls back and fails correctly' test_effective_net_mode
     run_test 'net-mode refreshes runtime scripts before restart' test_net_mode_reinstalls_runtime_scripts
@@ -385,4 +576,7 @@ run_common_tests() {
     run_test 'migrate_config is idempotent across multiple calls' test_migrate_config_idempotent
     run_test 'get_arch picks correct MIPS endianness across all sources' test_get_arch_mips_endianness
     run_test 'get_openwrt_arch reads sources in priority order' test_get_openwrt_arch_sources
+    run_test 'init extra_env overrides detected firewall mode' test_init_extra_env_overrides_firewall_mode
+    run_test 'init extra_args overrides userspace socks5/http-proxy defaults' test_init_extra_args_overrides_userspace_defaults
+    run_test 'init userspace defaults persist when extra_args is empty' test_init_extra_args_userspace_defaults_remain_without_override
 }

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -364,6 +364,67 @@ EOF
     run_with_test_shell "$LAST_SCRIPT"
 }
 
+test_create_uci_config_preserves_existing_user_lists() {
+    write_stub uci <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$TEST_DIR/uci.log"
+case "$*" in
+    "-q get tailscale.settings") exit 0 ;;
+    "-q get tailscale.settings.port") echo "41641"; exit 0 ;;
+    "-q get tailscale.settings.update_cron") echo "15 4 * * *"; exit 0 ;;
+    "-q get tailscale.settings.net_mode") echo "userspace"; exit 0 ;;
+    "-q get tailscale.settings.proxy_listen") echo "lan"; exit 0 ;;
+    "-q get tailscale.settings.log_stdout") echo "1"; exit 0 ;;
+    "-q get tailscale.settings.log_stderr") echo "1"; exit 0 ;;
+    set\ tailscale.settings.*) exit 0 ;;
+    "commit tailscale") exit 0 ;;
+    *) exit 1 ;;
+esac
+EOF
+
+    new_script manager-uci-preserve.sh <<'EOF'
+#!/bin/sh
+set -eu
+LIB_DIR="$REPO_ROOT/usr/lib/tailscale"
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. "$REPO_ROOT/tailscale-manager.sh"
+LOG_FILE="$TEST_DIR/tailscale-manager.log"
+
+CONFIG_FILE="$TEST_DIR/root/etc/config/tailscale"
+STATE_FILE="$TEST_DIR/root/etc/config/tailscaled.state"
+STATE_DIR="$TEST_DIR/root/etc/tailscale"
+mkdir -p "$(dirname "$CONFIG_FILE")"
+cat > "$CONFIG_FILE" <<'CONFIG'
+config tailscale 'settings'
+    option net_mode 'userspace'
+    option proxy_listen 'lan'
+    list extra_env 'GOMIPS=softfloat'
+    list extra_env 'TS_DEBUG_FIREWALL_MODE=nftables'
+    list extra_args '--socks5-server=192.168.10.1:1080'
+CONFIG
+
+download_repo_file() {
+    echo "download_repo_file should not run for existing config" >&2
+    exit 1
+}
+
+create_uci_config persistent /opt/tailscale small 1
+
+grep -Fq "list extra_env 'GOMIPS=softfloat'" "$CONFIG_FILE"
+grep -Fq "list extra_env 'TS_DEBUG_FIREWALL_MODE=nftables'" "$CONFIG_FILE"
+grep -Fq "list extra_args '--socks5-server=192.168.10.1:1080'" "$CONFIG_FILE"
+if grep -Fq 'set tailscale.settings.net_mode=auto' "$TEST_DIR/uci.log"; then
+    echo "net_mode should be preserved for existing config"
+    exit 1
+fi
+grep -Fq 'set tailscale.settings.bin_dir=/opt/tailscale' "$TEST_DIR/uci.log"
+grep -Fq 'set tailscale.settings.download_source=small' "$TEST_DIR/uci.log"
+grep -Fq 'set tailscale.settings.auto_update=1' "$TEST_DIR/uci.log"
+EOF
+
+    run_with_test_shell "$LAST_SCRIPT"
+}
+
 test_install_luci_app_reports_partial_failure() {
     new_script manager-luci-partial.sh <<EOF
 #!/bin/sh
@@ -912,6 +973,7 @@ run_deploy_tests() {
     run_test 'install-quiet rejects unsafe PERSISTENT_DIR env' test_install_quiet_rejects_unsafe_persistent_dir_env
     run_test 'install-quiet rejects unsafe configured bin_dir' test_install_quiet_rejects_unsafe_uci_bin_dir
     run_test 'install-version avoids managed file reinstall' test_install_version_quiet_does_not_reinstall_managed_files
+    run_test 'create_uci_config preserves existing user lists' test_create_uci_config_preserves_existing_user_lists
     run_test 'install_luci_app reports partial download failure' test_install_luci_app_reports_partial_failure
     run_test 'install_luci_app deploy rollback cleans first-install files' test_install_luci_app_deploy_rollback_first_install
     run_test 'install_luci_app deploy rollback restores old files on upgrade' test_install_luci_app_deploy_rollback_upgrade

--- a/usr/lib/tailscale/deploy.sh
+++ b/usr/lib/tailscale/deploy.sh
@@ -39,22 +39,42 @@ create_uci_config() {
         return 1
     fi
 
-    download_repo_file "$CONFIG_TEMPLATE_URL" "$CONFIG_FILE" 644 || return 1
+    if [ ! -f "$CONFIG_FILE" ]; then
+        download_repo_file "$CONFIG_TEMPLATE_URL" "$CONFIG_FILE" 644 || return 1
+    fi
 
-    uci -q batch <<EOF >/dev/null
-set tailscale.settings.enabled='1'
-set tailscale.settings.port='41641'
-set tailscale.settings.storage_mode='${storage_mode}'
-set tailscale.settings.bin_dir='${bin_dir}'
-set tailscale.settings.state_file='${STATE_FILE}'
-set tailscale.settings.statedir='${STATE_DIR}'
-set tailscale.settings.download_source='${download_source}'
-set tailscale.settings.auto_update='${auto_update}'
-set tailscale.settings.update_cron='30 3 * * *'
-set tailscale.settings.net_mode='auto'
-set tailscale.settings.log_stdout='1'
-set tailscale.settings.log_stderr='1'
-EOF
+    if ! uci -q get tailscale.settings >/dev/null 2>&1; then
+        uci set tailscale.settings='tailscale' >/dev/null || {
+            log_error "Failed to create tailscale.settings UCI section"
+            return 1
+        }
+    fi
+
+    uci_set_value() {
+        uci set "tailscale.settings.${1}=${2}" >/dev/null || return 1
+    }
+
+    uci_set_default() {
+        local option="$1"
+        local value="$2"
+        uci -q get "tailscale.settings.${option}" >/dev/null 2>&1 && return 0
+        uci_set_value "$option" "$value"
+    }
+
+    uci_set_value enabled '1' || return 1
+    uci_set_value storage_mode "$storage_mode" || return 1
+    uci_set_value bin_dir "$bin_dir" || return 1
+    uci_set_value state_file "$STATE_FILE" || return 1
+    uci_set_value statedir "$STATE_DIR" || return 1
+    uci_set_value download_source "$download_source" || return 1
+    uci_set_value auto_update "$auto_update" || return 1
+
+    uci_set_default port '41641' || return 1
+    uci_set_default update_cron '30 3 * * *' || return 1
+    uci_set_default net_mode 'auto' || return 1
+    uci_set_default proxy_listen 'localhost' || return 1
+    uci_set_default log_stdout '1' || return 1
+    uci_set_default log_stderr '1' || return 1
 
     if ! uci commit tailscale >/dev/null 2>&1; then
         log_error "Failed to commit ${CONFIG_FILE}"


### PR DESCRIPTION
## Summary

Address @lutzapps' final ask in #14: stop forcing users to hand-edit `/etc/init.d/tailscale` after every manager upgrade just to keep a few procd env vars and `tailscaled` flags (e.g. `GOMIPS=softfloat`, `GOMEMLIMIT=24MiB`, `--socks5-server=...`).

- New UCI lists `tailscale.settings.extra_env` and `tailscale.settings.extra_args` are read by the init script and injected via `procd_append_param env` / `procd_append_param command`. Entries persist across manager upgrades since the init script no longer owns them.
- Override-aware: if `extra_env` defines `TS_DEBUG_FIREWALL_MODE`, the script skips its auto-detected default; if `extra_args` includes `--socks5-server` / `--outbound-http-proxy-listen`, the userspace-mode default for that flag is skipped, so there is exactly one listener per port.
- `create_uci_config` is hardened to preserve user-modified UCI options on reinstall. Only install-time choices (`storage_mode`, `bin_dir`, `download_source`, `auto_update`, managed state paths) are still overwritten; `port`, `net_mode`, `proxy_listen`, `update_cron`, `log_stdout`, `log_stderr`, and any user-added list entries are retained. The config template is also no longer re-downloaded when the file already exists.
- Bumps `VERSION` to `4.1.1`. Docs (EN + ZH) get a new **Advanced: Custom env and CLI arguments** section under `/guide/configuration` and concise `v4.1.1` changelog entries.

## Test plan

- [x] `sh tests/run.sh` — 97/97 pass, including:
  - `init extra_env overrides detected firewall mode`
  - `init extra_args overrides userspace socks5/http-proxy defaults`
  - `init userspace defaults persist when extra_args is empty`
  - `create_uci_config preserves existing user lists`
- [ ] Reviewer sanity-check the EN/ZH configuration docs render correctly on the docs site
- [ ] @lutzapps verifies on TP-Link Archer C7 (mips_24kc) that `uci add_list tailscale.settings.extra_env='GOMIPS=softfloat'` + `restart` injects the env var as expected

Ref #14