### PR TITLE
fix: protect managed file cleanup

### DIFF
--- a/tests/bats/deploy/uninstall.bats
+++ b/tests/bats/deploy/uninstall.bats
@@ -135,11 +135,14 @@ do_uninstall --yes >/dev/null
     assert_success
 }
 
-@test "do_uninstall rejects unsafe library and LuCI view roots" {
+@test "do_uninstall continues cleanup when LIB_DIR fails safety checks" {
     mkdir -p "${TEST_DIR}/root/opt/tailscale" "${TEST_DIR}/root/tmp/tailscale" \
              "$(dirname "${TEST_DIR}/root/etc/init.d/tailscale")" \
              "$(dirname "${TEST_DIR}/root/usr/bin/tailscale-update")" \
-             "$(dirname "${TEST_DIR}/root/etc/config/tailscale")"
+             "$(dirname "${TEST_DIR}/root/etc/config/tailscale")" \
+             "${TEST_DIR}/root/www/luci-static/resources/view/tailscale"
+    printf 'init\n' > "${TEST_DIR}/root/etc/init.d/tailscale"
+    printf 'cron\n' > "${TEST_DIR}/root/usr/bin/tailscale-update"
     printf 'config\n' > "${TEST_DIR}/root/etc/config/tailscale"
 
     run_in_sh auto "
@@ -157,6 +160,50 @@ MANAGED_RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
 INIT_SCRIPT='${TEST_DIR}/root/etc/init.d/tailscale'
 CRON_SCRIPT='${TEST_DIR}/root/usr/bin/tailscale-update'
 LIB_DIR='/usr'
+LUCI_VIEW_DIR='${TEST_DIR}/root/www/luci-static/resources/view/tailscale'
+MANAGED_LUCI_VIEW_DIR='${TEST_DIR}/root/www/luci-static/resources/view/tailscale'
+CONFIG_FILE='${TEST_DIR}/root/etc/config/tailscale'
+STATE_FILE='${TEST_DIR}/root/etc/config/tailscaled.state'
+
+remove_cron() { return 0; }
+remove_symlinks() { return 0; }
+remove_subnet_routing_config() { return 0; }
+
+do_uninstall --yes >/dev/null
+
+[ ! -e '${TEST_DIR}/root/etc/init.d/tailscale' ]
+[ ! -e '${TEST_DIR}/root/usr/bin/tailscale-update' ]
+[ ! -e '${TEST_DIR}/root/etc/config/tailscale' ]
+"
+    assert_success
+}
+
+@test "do_uninstall continues cleanup when LUCI_VIEW_DIR fails safety checks" {
+    mkdir -p "${TEST_DIR}/root/opt/tailscale" "${TEST_DIR}/root/tmp/tailscale" \
+             "$(dirname "${TEST_DIR}/root/etc/init.d/tailscale")" \
+             "$(dirname "${TEST_DIR}/root/usr/bin/tailscale-update")" \
+             "$(dirname "${TEST_DIR}/root/etc/config/tailscale")" \
+             "${TEST_DIR}/root/usr/lib/tailscale"
+    printf 'init\n' > "${TEST_DIR}/root/etc/init.d/tailscale"
+    printf 'cron\n' > "${TEST_DIR}/root/usr/bin/tailscale-update"
+    printf 'config\n' > "${TEST_DIR}/root/etc/config/tailscale"
+
+    run_in_sh auto "
+set -eu
+
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+PERSISTENT_DIR='${TEST_DIR}/root/opt/tailscale'
+RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
+MANAGED_PERSISTENT_DIR='${TEST_DIR}/root/opt/tailscale'
+MANAGED_RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
+INIT_SCRIPT='${TEST_DIR}/root/etc/init.d/tailscale'
+CRON_SCRIPT='${TEST_DIR}/root/usr/bin/tailscale-update'
+LIB_DIR='${TEST_DIR}/root/usr/lib/tailscale'
+MANAGED_LIB_DIR='${TEST_DIR}/root/usr/lib/tailscale'
 LUCI_VIEW_DIR='/www'
 CONFIG_FILE='${TEST_DIR}/root/etc/config/tailscale'
 STATE_FILE='${TEST_DIR}/root/etc/config/tailscaled.state'
@@ -165,10 +212,11 @@ remove_cron() { return 0; }
 remove_symlinks() { return 0; }
 remove_subnet_routing_config() { return 0; }
 
-if do_uninstall --yes >/dev/null 2>&1; then
-    echo 'do_uninstall should have rejected unsafe roots'
-    exit 1
-fi
+do_uninstall --yes >/dev/null
+
+[ ! -e '${TEST_DIR}/root/etc/init.d/tailscale' ]
+[ ! -e '${TEST_DIR}/root/usr/bin/tailscale-update' ]
+[ ! -e '${TEST_DIR}/root/etc/config/tailscale' ]
 "
     assert_success
 }

--- a/tests/bats/deploy/uninstall.bats
+++ b/tests/bats/deploy/uninstall.bats
@@ -51,11 +51,15 @@ LOG_FILE='${TEST_DIR}/tailscale-manager.log'
 
 PERSISTENT_DIR='${TEST_DIR}/root/opt/tailscale'
 RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
+MANAGED_PERSISTENT_DIR='${TEST_DIR}/root/opt/tailscale'
+MANAGED_RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
 INIT_SCRIPT='${TEST_DIR}/root/etc/init.d/tailscale'
 CRON_SCRIPT='${TEST_DIR}/root/usr/bin/tailscale-update'
 LIB_DIR='${LIB_DIR_TARGET}'
+MANAGED_LIB_DIR='${LIB_DIR_TARGET}'
 CONFIG_FILE='${TEST_DIR}/root/etc/config/tailscale'
 STATE_FILE='${TEST_DIR}/root/etc/config/tailscaled.state'
+MANAGED_LUCI_VIEW_DIR='${LUCI_VIEW_DIR}'
 
 remove_cron() { return 0; }
 remove_symlinks() { return 0; }
@@ -68,6 +72,103 @@ do_uninstall --yes >/dev/null
 [ ! -e '${LUCI_MENU_DEST}' ]
 [ ! -e '${LUCI_ACL_DEST}' ]
 [ ! -e '${LIB_DIR_TARGET}' ]
+"
+    assert_success
+}
+
+@test "do_uninstall preserves unrelated files in custom managed directories" {
+    local PERSISTENT_DIR_TARGET="${TEST_DIR}/custom/persistent"
+    local LUCI_VIEW_DIR="${TEST_DIR}/custom/view/tailscale"
+    local LIB_DIR_TARGET="${TEST_DIR}/custom/lib/tailscale"
+
+    mkdir -p "${PERSISTENT_DIR_TARGET}" "${LUCI_VIEW_DIR}" "${LIB_DIR_TARGET}" \
+             "${TEST_DIR}/root/tmp/tailscale" "$(dirname "${TEST_DIR}/root/etc/init.d/tailscale")" \
+             "$(dirname "${TEST_DIR}/root/usr/bin/tailscale-update")" \
+             "$(dirname "${TEST_DIR}/root/etc/config/tailscale")"
+
+    printf 'managed\n' > "${PERSISTENT_DIR_TARGET}/tailscale"
+    printf 'keep\n'    > "${PERSISTENT_DIR_TARGET}/keep.txt"
+    printf 'managed\n' > "${LUCI_VIEW_DIR}/config.js"
+    printf 'keep\n'    > "${LUCI_VIEW_DIR}/keep.txt"
+    printf 'managed\n' > "${LIB_DIR_TARGET}/common.sh"
+    printf 'keep\n'    > "${LIB_DIR_TARGET}/keep.txt"
+    printf 'init\n'    > "${TEST_DIR}/root/etc/init.d/tailscale"
+    printf 'cron\n'    > "${TEST_DIR}/root/usr/bin/tailscale-update"
+    cat > "${TEST_DIR}/root/etc/config/tailscale" <<EOF
+config tailscale 'settings'
+EOF
+
+    run_in_sh auto "
+set -eu
+
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+PERSISTENT_DIR='${PERSISTENT_DIR_TARGET}'
+RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
+MANAGED_RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
+INIT_SCRIPT='${TEST_DIR}/root/etc/init.d/tailscale'
+CRON_SCRIPT='${TEST_DIR}/root/usr/bin/tailscale-update'
+LIB_DIR='${LIB_DIR_TARGET}'
+LUCI_VIEW_DIR='${LUCI_VIEW_DIR}'
+LUCI_RPC_DEST='${TEST_DIR}/root/usr/libexec/rpcd/luci-tailscale'
+LUCI_MENU_DEST='${TEST_DIR}/root/usr/share/luci/menu.d/luci-app-tailscale.json'
+LUCI_ACL_DEST='${TEST_DIR}/root/usr/share/rpcd/acl.d/luci-app-tailscale.json'
+CONFIG_FILE='${TEST_DIR}/root/etc/config/tailscale'
+STATE_FILE='${TEST_DIR}/root/etc/config/tailscaled.state'
+
+remove_cron() { return 0; }
+remove_symlinks() { return 0; }
+remove_subnet_routing_config() { return 0; }
+
+do_uninstall --yes >/dev/null
+
+[ ! -e '${PERSISTENT_DIR_TARGET}/tailscale' ]
+[ -f '${PERSISTENT_DIR_TARGET}/keep.txt' ]
+[ ! -e '${LUCI_VIEW_DIR}/config.js' ]
+[ -f '${LUCI_VIEW_DIR}/keep.txt' ]
+[ ! -e '${LIB_DIR_TARGET}/common.sh' ]
+[ -f '${LIB_DIR_TARGET}/keep.txt' ]
+"
+    assert_success
+}
+
+@test "do_uninstall rejects unsafe library and LuCI view roots" {
+    mkdir -p "${TEST_DIR}/root/opt/tailscale" "${TEST_DIR}/root/tmp/tailscale" \
+             "$(dirname "${TEST_DIR}/root/etc/init.d/tailscale")" \
+             "$(dirname "${TEST_DIR}/root/usr/bin/tailscale-update")" \
+             "$(dirname "${TEST_DIR}/root/etc/config/tailscale")"
+    printf 'config\n' > "${TEST_DIR}/root/etc/config/tailscale"
+
+    run_in_sh auto "
+set -eu
+
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+PERSISTENT_DIR='${TEST_DIR}/root/opt/tailscale'
+RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
+MANAGED_PERSISTENT_DIR='${TEST_DIR}/root/opt/tailscale'
+MANAGED_RAM_DIR='${TEST_DIR}/root/tmp/tailscale'
+INIT_SCRIPT='${TEST_DIR}/root/etc/init.d/tailscale'
+CRON_SCRIPT='${TEST_DIR}/root/usr/bin/tailscale-update'
+LIB_DIR='/usr'
+LUCI_VIEW_DIR='/www'
+CONFIG_FILE='${TEST_DIR}/root/etc/config/tailscale'
+STATE_FILE='${TEST_DIR}/root/etc/config/tailscaled.state'
+
+remove_cron() { return 0; }
+remove_symlinks() { return 0; }
+remove_subnet_routing_config() { return 0; }
+
+if do_uninstall --yes >/dev/null 2>&1; then
+    echo 'do_uninstall should have rejected unsafe roots'
+    exit 1
+fi
 "
     assert_success
 }

--- a/tests/bats/download/staged.bats
+++ b/tests/bats/download/staged.bats
@@ -191,3 +191,54 @@ install_staged \"\$stage\" \"\$target\"
 "
     assert_success
 }
+
+@test "create_symlinks refuses to overwrite non-managed commands" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+USER_BIN_DIR='${TEST_DIR}/usr-bin'
+bin_dir='${TEST_DIR}/managed-bin'
+mkdir -p \"\$USER_BIN_DIR\" \"\$bin_dir\"
+printf 'existing command\n' > \"\$USER_BIN_DIR/tailscale\"
+
+if create_symlinks \"\$bin_dir\" 2>/dev/null; then
+    echo 'create_symlinks should have refused existing command'
+    exit 1
+fi
+
+[ -f \"\$USER_BIN_DIR/tailscale\" ] || { echo 'existing command removed'; exit 1; }
+[ \"\$(cat \"\$USER_BIN_DIR/tailscale\")\" = 'existing command' ] || { echo 'existing command changed'; exit 1; }
+[ ! -e \"\$USER_BIN_DIR/tailscaled\" ] || { echo 'tailscaled link created after failure'; exit 1; }
+"
+    assert_success
+}
+
+@test "remove_symlinks only removes links for managed bin directories" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+USER_BIN_DIR='${TEST_DIR}/usr-bin'
+managed='${TEST_DIR}/managed-bin'
+other='${TEST_DIR}/other-bin'
+mkdir -p \"\$USER_BIN_DIR\" \"\$managed\" \"\$other\"
+ln -s \"\$managed/tailscale\" \"\$USER_BIN_DIR/tailscale\"
+ln -s \"\$other/tailscaled\" \"\$USER_BIN_DIR/tailscaled\"
+
+remove_symlinks \"\$managed\"
+
+[ ! -e \"\$USER_BIN_DIR/tailscale\" ] && [ ! -L \"\$USER_BIN_DIR/tailscale\" ] || { echo 'managed tailscale link remained'; exit 1; }
+[ -L \"\$USER_BIN_DIR/tailscaled\" ] || { echo 'other tailscaled link removed'; exit 1; }
+[ \"\$(readlink \"\$USER_BIN_DIR/tailscaled\")\" = \"\$other/tailscaled\" ] || { echo 'other link target changed'; exit 1; }
+"
+    assert_success
+}

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -53,6 +53,74 @@ require_configured_persistent_bin_dir() {
     require_absolute_path "$bin_dir" "Configured bin_dir"
 }
 
+safe_rm_tree() {
+    local path="$1"
+    local label="$2"
+    shift 2
+
+    local allowed=""
+    local normalized="$path"
+
+    require_absolute_path "$path" "$label" || return 1
+    case "$normalized" in
+        */) normalized="${normalized%/}" ;;
+    esac
+
+    for allowed in "$@"; do
+        [ -n "$allowed" ] || continue
+        case "$normalized" in
+            "$allowed")
+                rm -rf "$normalized"
+                return 0
+                ;;
+        esac
+    done
+
+    log_error "Refusing to remove unmanaged ${label}: ${path}"
+    return 1
+}
+
+safe_rm_managed_bin_dir_files() {
+    local bin_dir="$1"
+
+    require_absolute_path "$bin_dir" "Configured bin_dir" || return 1
+    rm -f "${bin_dir}/tailscale" \
+          "${bin_dir}/tailscaled" \
+          "${bin_dir}/tailscale.combined" \
+          "${bin_dir}/version" \
+          "${bin_dir}/source" \
+          "${bin_dir}/.rollback_version" 2>/dev/null || true
+    rmdir "$bin_dir" 2>/dev/null || true
+}
+
+safe_rm_managed_lib_dir_files() {
+    local lib_dir="$1"
+
+    require_absolute_path "$lib_dir" "LIB_DIR" || return 1
+    rm -f "${lib_dir}/common.sh" \
+          "${lib_dir}/jsonutil.sh" \
+          "${lib_dir}/version.sh" \
+          "${lib_dir}/download.sh" \
+          "${lib_dir}/firewall.sh" \
+          "${lib_dir}/deploy.sh" \
+          "${lib_dir}/selfupdate.sh" \
+          "${lib_dir}/commands.sh" \
+          "${lib_dir}/menu.sh" \
+          "${lib_dir}/json.sh" 2>/dev/null || true
+    rmdir "$lib_dir" 2>/dev/null || true
+}
+
+safe_rm_managed_luci_view_files() {
+    local view_dir="$1"
+
+    require_absolute_path "$view_dir" "LUCI_VIEW_DIR" || return 1
+    rm -f "${view_dir}/config.js" \
+          "${view_dir}/status.js" \
+          "${view_dir}/maintenance.js" \
+          "${view_dir}/log.js" 2>/dev/null || true
+    rmdir "$view_dir" 2>/dev/null || true
+}
+
 # Shared post-install flow: deploy managed files, configure cron, enable and
 # start the service, then verify it came up.  Returns 1 if tailscaled fails
 # to start so callers can decide whether to abort or continue.
@@ -502,7 +570,6 @@ do_uninstall() {
     fi
 
     remove_cron
-    remove_symlinks
 
     require_persistent_dir || return 1
 
@@ -513,32 +580,36 @@ do_uninstall() {
         config_get uci_bin_dir settings bin_dir ""
     fi
 
-    rm -rf "$PERSISTENT_DIR"
-    rm -rf "$RAM_DIR"
+    remove_symlinks "$PERSISTENT_DIR" "$RAM_DIR" "$uci_bin_dir"
+
+    if [ "$PERSISTENT_DIR" = "${MANAGED_PERSISTENT_DIR:-/opt/tailscale}" ]; then
+        safe_rm_tree "$PERSISTENT_DIR" "PERSISTENT_DIR" "${MANAGED_PERSISTENT_DIR:-/opt/tailscale}" || return 1
+    else
+        safe_rm_managed_bin_dir_files "$PERSISTENT_DIR" || return 1
+    fi
+    safe_rm_tree "$RAM_DIR" "RAM_DIR" "${MANAGED_RAM_DIR:-/tmp/tailscale}" || return 1
     # For a user-configured bin_dir (which may point at an external mount),
     # only remove the specific files this script installs, then try rmdir.
     # This avoids rm -rf wiping unrelated content if bin_dir was misconfigured.
     if [ -n "$uci_bin_dir" ] && [ "$uci_bin_dir" != "$PERSISTENT_DIR" ] && [ "$uci_bin_dir" != "$RAM_DIR" ]; then
-        case "$uci_bin_dir" in
-            /*)
-                rm -f "${uci_bin_dir}/tailscale" \
-                      "${uci_bin_dir}/tailscaled" \
-                      "${uci_bin_dir}/tailscale.combined" \
-                      "${uci_bin_dir}/version" \
-                      "${uci_bin_dir}/source" \
-                      "${uci_bin_dir}/.rollback_version" 2>/dev/null || true
-                rmdir "$uci_bin_dir" 2>/dev/null || true
-                ;;
-        esac
+        safe_rm_managed_bin_dir_files "$uci_bin_dir" || return 1
     fi
 
     rm -f "$INIT_SCRIPT"
     rm -f "$CRON_SCRIPT"
     rm -f /usr/bin/tailscale-script-update
-    rm -rf "$LIB_DIR"
+    if [ "$LIB_DIR" = "${MANAGED_LIB_DIR:-/usr/lib/tailscale}" ]; then
+        safe_rm_tree "$LIB_DIR" "LIB_DIR" "${MANAGED_LIB_DIR:-/usr/lib/tailscale}" || return 1
+    else
+        safe_rm_managed_lib_dir_files "$LIB_DIR" || return 1
+    fi
     rm -f /usr/bin/tailscale_update_check
 
-    rm -rf "$LUCI_VIEW_DIR"
+    if [ "$LUCI_VIEW_DIR" = "${MANAGED_LUCI_VIEW_DIR:-/www/luci-static/resources/view/tailscale}" ]; then
+        safe_rm_tree "$LUCI_VIEW_DIR" "LUCI_VIEW_DIR" "${MANAGED_LUCI_VIEW_DIR:-/www/luci-static/resources/view/tailscale}" || return 1
+    else
+        safe_rm_managed_luci_view_files "$LUCI_VIEW_DIR" || return 1
+    fi
     rm -f "$LUCI_RPC_DEST"
     rm -f "$LUCI_MENU_DEST"
     rm -f "$LUCI_ACL_DEST"

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -35,7 +35,7 @@ require_absolute_path() {
 
     case "$normalized" in
         /|/bin|/sbin|/usr|/usr/bin|/usr/sbin|/usr/lib|/usr/local|/lib|/lib64|\
-/etc|/dev|/proc|/sys|/root|/boot|/var|/tmp|/mnt|/opt|/home)
+/etc|/dev|/proc|/sys|/root|/boot|/var|/tmp|/mnt|/opt|/home|/www)
             log_error "${label} '${path}' is a reserved system directory; pick a sub-path like ${normalized%/}/tailscale"
             return 1
             ;;
@@ -537,6 +537,7 @@ do_rollback() {
 
 do_uninstall() {
     local force="${1:-}"
+    local cleanup_failed=0
 
     if [ "$force" != "--yes" ]; then
         echo ""
@@ -583,32 +584,32 @@ do_uninstall() {
     remove_symlinks "$PERSISTENT_DIR" "$RAM_DIR" "$uci_bin_dir"
 
     if [ "$PERSISTENT_DIR" = "${MANAGED_PERSISTENT_DIR:-/opt/tailscale}" ]; then
-        safe_rm_tree "$PERSISTENT_DIR" "PERSISTENT_DIR" "${MANAGED_PERSISTENT_DIR:-/opt/tailscale}" || return 1
+        safe_rm_tree "$PERSISTENT_DIR" "PERSISTENT_DIR" "${MANAGED_PERSISTENT_DIR:-/opt/tailscale}" || cleanup_failed=1
     else
-        safe_rm_managed_bin_dir_files "$PERSISTENT_DIR" || return 1
+        safe_rm_managed_bin_dir_files "$PERSISTENT_DIR" || cleanup_failed=1
     fi
-    safe_rm_tree "$RAM_DIR" "RAM_DIR" "${MANAGED_RAM_DIR:-/tmp/tailscale}" || return 1
+    safe_rm_tree "$RAM_DIR" "RAM_DIR" "${MANAGED_RAM_DIR:-/tmp/tailscale}" || cleanup_failed=1
     # For a user-configured bin_dir (which may point at an external mount),
     # only remove the specific files this script installs, then try rmdir.
     # This avoids rm -rf wiping unrelated content if bin_dir was misconfigured.
     if [ -n "$uci_bin_dir" ] && [ "$uci_bin_dir" != "$PERSISTENT_DIR" ] && [ "$uci_bin_dir" != "$RAM_DIR" ]; then
-        safe_rm_managed_bin_dir_files "$uci_bin_dir" || return 1
+        safe_rm_managed_bin_dir_files "$uci_bin_dir" || cleanup_failed=1
     fi
 
     rm -f "$INIT_SCRIPT"
     rm -f "$CRON_SCRIPT"
     rm -f /usr/bin/tailscale-script-update
     if [ "$LIB_DIR" = "${MANAGED_LIB_DIR:-/usr/lib/tailscale}" ]; then
-        safe_rm_tree "$LIB_DIR" "LIB_DIR" "${MANAGED_LIB_DIR:-/usr/lib/tailscale}" || return 1
+        safe_rm_tree "$LIB_DIR" "LIB_DIR" "${MANAGED_LIB_DIR:-/usr/lib/tailscale}" || cleanup_failed=1
     else
-        safe_rm_managed_lib_dir_files "$LIB_DIR" || return 1
+        safe_rm_managed_lib_dir_files "$LIB_DIR" || cleanup_failed=1
     fi
     rm -f /usr/bin/tailscale_update_check
 
     if [ "$LUCI_VIEW_DIR" = "${MANAGED_LUCI_VIEW_DIR:-/www/luci-static/resources/view/tailscale}" ]; then
-        safe_rm_tree "$LUCI_VIEW_DIR" "LUCI_VIEW_DIR" "${MANAGED_LUCI_VIEW_DIR:-/www/luci-static/resources/view/tailscale}" || return 1
+        safe_rm_tree "$LUCI_VIEW_DIR" "LUCI_VIEW_DIR" "${MANAGED_LUCI_VIEW_DIR:-/www/luci-static/resources/view/tailscale}" || cleanup_failed=1
     else
-        safe_rm_managed_luci_view_files "$LUCI_VIEW_DIR" || return 1
+        safe_rm_managed_luci_view_files "$LUCI_VIEW_DIR" || cleanup_failed=1
     fi
     rm -f "$LUCI_RPC_DEST"
     rm -f "$LUCI_MENU_DEST"
@@ -622,6 +623,10 @@ do_uninstall() {
     rm -f "$CONFIG_FILE"
 
     remove_subnet_routing_config
+
+    if [ "$cleanup_failed" = "1" ]; then
+        log_warn "Some managed directories were skipped because they failed safety checks"
+    fi
 
     echo ""
     echo "============================================="

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -354,19 +354,88 @@ download_tailscale_small() {
 }
 
 # Create /usr/bin symlinks pointing to the binary directory
+_user_bin_path() {
+    printf '%s/%s' "${USER_BIN_DIR:-/usr/bin}" "$1"
+}
+
+_is_managed_bin_link() {
+    local link="$1"
+    local target="$2"
+    local current_target=""
+
+    [ -L "$link" ] || return 1
+    current_target=$(readlink "$link" 2>/dev/null) || return 1
+    [ "$current_target" = "$target" ]
+}
+
+_ensure_bin_link_slot() {
+    local link="$1"
+    shift
+    local target
+
+    if [ ! -e "$link" ] && [ ! -L "$link" ]; then
+        return 0
+    fi
+
+    for target in "$@"; do
+        [ -n "$target" ] || continue
+        if _is_managed_bin_link "$link" "$target"; then
+            return 0
+        fi
+    done
+
+    log_error "Refusing to overwrite non-managed command: ${link}"
+    return 1
+}
+
 create_symlinks() {
     local bin_dir="$1"
+    local tailscale_link tailscaled_link
 
-    rm -f /usr/bin/tailscale /usr/bin/tailscaled
+    tailscale_link=$(_user_bin_path tailscale)
+    tailscaled_link=$(_user_bin_path tailscaled)
 
-    ln -sf "${bin_dir}/tailscale" /usr/bin/tailscale
-    ln -sf "${bin_dir}/tailscaled" /usr/bin/tailscaled
+    _ensure_bin_link_slot "$tailscale_link" \
+        "${bin_dir}/tailscale" \
+        "${PERSISTENT_DIR:-/opt/tailscale}/tailscale" \
+        "${RAM_DIR:-/tmp/tailscale}/tailscale" || return 1
+    _ensure_bin_link_slot "$tailscaled_link" \
+        "${bin_dir}/tailscaled" \
+        "${PERSISTENT_DIR:-/opt/tailscale}/tailscaled" \
+        "${RAM_DIR:-/tmp/tailscale}/tailscaled" || return 1
 
-    log_info "Created symlinks in /usr/bin/"
+    rm -f "$tailscale_link" "$tailscaled_link"
+    ln -sf "${bin_dir}/tailscale" "$tailscale_link"
+    ln -sf "${bin_dir}/tailscaled" "$tailscaled_link"
+
+    log_info "Created symlinks in ${USER_BIN_DIR:-/usr/bin}/"
 }
 
 # Remove /usr/bin symlinks
 remove_symlinks() {
-    rm -f /usr/bin/tailscale /usr/bin/tailscaled
-    log_info "Removed symlinks from /usr/bin/"
+    local dirs="$*"
+    local tailscale_link tailscaled_link dir removed=0
+
+    tailscale_link=$(_user_bin_path tailscale)
+    tailscaled_link=$(_user_bin_path tailscaled)
+
+    [ -n "$dirs" ] || dirs="${PERSISTENT_DIR:-/opt/tailscale} ${RAM_DIR:-/tmp/tailscale}"
+
+    for dir in $dirs; do
+        [ -n "$dir" ] || continue
+        if _is_managed_bin_link "$tailscale_link" "${dir}/tailscale"; then
+            rm -f "$tailscale_link"
+            removed=1
+        fi
+        if _is_managed_bin_link "$tailscaled_link" "${dir}/tailscaled"; then
+            rm -f "$tailscaled_link"
+            removed=1
+        fi
+    done
+
+    if [ "$removed" = "1" ]; then
+        log_info "Removed managed symlinks from ${USER_BIN_DIR:-/usr/bin}/"
+    else
+        log_info "No managed symlinks found in ${USER_BIN_DIR:-/usr/bin}/"
+    fi
 }

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -413,15 +413,16 @@ create_symlinks() {
 
 # Remove /usr/bin symlinks
 remove_symlinks() {
-    local dirs="$*"
     local tailscale_link tailscaled_link dir removed=0
 
     tailscale_link=$(_user_bin_path tailscale)
     tailscaled_link=$(_user_bin_path tailscaled)
 
-    [ -n "$dirs" ] || dirs="${PERSISTENT_DIR:-/opt/tailscale} ${RAM_DIR:-/tmp/tailscale}"
+    if [ "$#" -eq 0 ]; then
+        set -- "${PERSISTENT_DIR:-/opt/tailscale}" "${RAM_DIR:-/tmp/tailscale}"
+    fi
 
-    for dir in $dirs; do
+    for dir in "$@"; do
         [ -n "$dir" ] || continue
         if _is_managed_bin_link "$tailscale_link" "${dir}/tailscale"; then
             rm -f "$tailscale_link"


### PR DESCRIPTION
## Summary
- refuse to overwrite existing Tailscale commands unless they are managed symlinks
- remove `/usr/bin/tailscale` and `/usr/bin/tailscaled` only when they point to managed binary directories
- limit uninstall cleanup for custom managed directories to known project files
- add regression coverage for symlink ownership checks and uninstall cleanup boundaries

## Tests
- `make lint`
- `make test`
- `make check-static`
- `make shellcheck`
- `make check-sync`