### PR TITLE
fix: validate install options and rollback staged files

### DIFF
--- a/tests/bats/deploy/install.bats
+++ b/tests/bats/deploy/install.bats
@@ -184,6 +184,10 @@ done
 @test "install-quiet rejects invalid option values" {
     run_in_sh auto "$(_install_stubs)
 
+if cmd_install --source --storage >/dev/null 2>&1; then
+    echo 'cmd_install should reject option-like source value'
+    exit 1
+fi
 if cmd_install --source mirror >/dev/null 2>&1; then
     echo 'cmd_install should reject invalid source'
     exit 1

--- a/tests/bats/deploy/install.bats
+++ b/tests/bats/deploy/install.bats
@@ -167,6 +167,39 @@ done
     assert_success
 }
 
+@test "install-quiet rejects missing option values" {
+    run_in_sh auto "$(_install_stubs)
+
+for args in '--source' '--storage' '--auto-update' '--bin-dir'; do
+    # shellcheck disable=SC2086
+    if cmd_install \$args >/dev/null 2>&1; then
+        echo 'cmd_install should reject missing option value'
+        exit 1
+    fi
+done
+"
+    assert_success
+}
+
+@test "install-quiet rejects invalid option values" {
+    run_in_sh auto "$(_install_stubs)
+
+if cmd_install --source mirror >/dev/null 2>&1; then
+    echo 'cmd_install should reject invalid source'
+    exit 1
+fi
+if cmd_install --storage flash >/dev/null 2>&1; then
+    echo 'cmd_install should reject invalid storage'
+    exit 1
+fi
+if cmd_install --auto-update yes >/dev/null 2>&1; then
+    echo 'cmd_install should reject invalid auto-update value'
+    exit 1
+fi
+"
+    assert_success
+}
+
 @test "install-quiet rejects unsafe PERSISTENT_DIR env" {
     run_in_sh auto "$(_install_stubs)
 PERSISTENT_DIR='/'
@@ -215,6 +248,25 @@ fi
 grep -Fq 'init stop' \"\$INIT_CALLS_LOG\"
 grep -Fq 'init enable' \"\$INIT_CALLS_LOG\"
 grep -Fq 'init start' \"\$INIT_CALLS_LOG\"
+"
+    assert_success
+}
+
+@test "install-version rejects missing and invalid option values" {
+    run_in_sh auto "$(_install_stubs)
+
+if cmd_install_version 1.77.0 --source >/dev/null 2>&1; then
+    echo 'cmd_install_version should reject missing source value'
+    exit 1
+fi
+if cmd_install_version 1.77.0 --bin-dir >/dev/null 2>&1; then
+    echo 'cmd_install_version should reject missing bin-dir value'
+    exit 1
+fi
+if cmd_install_version 1.77.0 --source mirror >/dev/null 2>&1; then
+    echo 'cmd_install_version should reject invalid source'
+    exit 1
+fi
 "
     assert_success
 }

--- a/tests/bats/download/staged.bats
+++ b/tests/bats/download/staged.bats
@@ -233,6 +233,48 @@ fi
     assert_success
 }
 
+@test "install_staged restores old combined layout when deploy fails" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+stage='${TEST_DIR}/stage'
+target='${TEST_DIR}/target'
+mkdir -p \"\$stage\" \"\$target\"
+echo 'new-combined-bin' > \"\$stage/tailscale.combined\"
+echo '2.0.0' > \"\$stage/version\"
+echo 'official' > \"\$stage/source\"
+echo 'old-combined-bin' > \"\$target/tailscale.combined\"
+(cd \"\$target\" && ln -s tailscale.combined tailscale && ln -s tailscale.combined tailscaled)
+echo '1.0.0' > \"\$target/version\"
+echo 'small' > \"\$target/source\"
+
+mv() {
+    case \"\$2\" in
+        \"\$target/tailscale.combined\") return 1 ;;
+    esac
+    command mv \"\$@\"
+}
+
+if install_staged \"\$stage\" \"\$target\" 2>/dev/null; then
+    echo 'install_staged should have failed'
+    exit 1
+fi
+
+[ -f \"\$target/tailscale.combined\" ] || { echo 'tailscale.combined missing'; exit 1; }
+[ \"\$(cat \"\$target/tailscale.combined\")\" = 'old-combined-bin' ] || { echo 'old combined binary not restored'; exit 1; }
+[ -L \"\$target/tailscale\" ] || { echo 'tailscale should be symlink'; exit 1; }
+[ -L \"\$target/tailscaled\" ] || { echo 'tailscaled should be symlink'; exit 1; }
+[ \"\$(cat \"\$target/version\")\" = '1.0.0' ] || { echo 'old version not restored'; exit 1; }
+[ \"\$(cat \"\$target/source\")\" = 'small' ] || { echo 'old source not restored'; exit 1; }
+"
+    assert_success
+}
+
 @test "create_symlinks refuses to overwrite non-managed commands" {
     run_in_sh auto "
 set -eu

--- a/tests/bats/download/staged.bats
+++ b/tests/bats/download/staged.bats
@@ -192,6 +192,47 @@ install_staged \"\$stage\" \"\$target\"
     assert_success
 }
 
+@test "install_staged restores old official layout when deploy fails" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+stage='${TEST_DIR}/stage'
+target='${TEST_DIR}/target'
+mkdir -p \"\$stage\" \"\$target\"
+echo 'new-tailscaled' > \"\$stage/tailscaled\"
+echo 'new-tailscale' > \"\$stage/tailscale\"
+echo '2.0.0' > \"\$stage/version\"
+echo 'official' > \"\$stage/source\"
+echo 'old-tailscaled' > \"\$target/tailscaled\"
+echo 'old-tailscale' > \"\$target/tailscale\"
+echo '1.0.0' > \"\$target/version\"
+echo 'small' > \"\$target/source\"
+
+mv() {
+    case \"\$2\" in
+        \"\$target/tailscale\") return 1 ;;
+    esac
+    command mv \"\$@\"
+}
+
+if install_staged \"\$stage\" \"\$target\" 2>/dev/null; then
+    echo 'install_staged should have failed'
+    exit 1
+fi
+
+[ \"\$(cat \"\$target/tailscaled\")\" = 'old-tailscaled' ] || { echo 'old tailscaled not restored'; exit 1; }
+[ \"\$(cat \"\$target/tailscale\")\" = 'old-tailscale' ] || { echo 'old tailscale not restored'; exit 1; }
+[ \"\$(cat \"\$target/version\")\" = '1.0.0' ] || { echo 'old version not restored'; exit 1; }
+[ \"\$(cat \"\$target/source\")\" = 'small' ] || { echo 'old source not restored'; exit 1; }
+"
+    assert_success
+}
+
 @test "create_symlinks refuses to overwrite non-managed commands" {
     run_in_sh auto "
 set -eu

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -61,6 +61,12 @@ require_option_value() {
         log_error "Option ${option} requires a value"
         return 1
     fi
+    case "$value" in
+        --*)
+            log_error "Option ${option} value looks like another option: ${value}"
+            return 1
+            ;;
+    esac
 }
 
 validate_download_source() {

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -1007,6 +1007,7 @@ cmd_install() {
     local persistent_bin_dir="$PERSISTENT_DIR"
     local bin_dir="$PERSISTENT_DIR"
 
+    # Validate CLI options (or defaults) before loading UCI config
     validate_download_source "$download_source" || return 1
     validate_storage_mode "$storage_mode" || return 1
     validate_auto_update_flag "$auto_update" || return 1
@@ -1020,6 +1021,7 @@ cmd_install() {
         [ -z "$opt_bin_dir" ] && config_get persistent_bin_dir settings bin_dir "$persistent_bin_dir"
     fi
 
+    # Re-validate after UCI config may have overridden values
     validate_download_source "$download_source" || return 1
     validate_storage_mode "$storage_mode" || return 1
     validate_auto_update_flag "$auto_update" || return 1
@@ -1115,6 +1117,7 @@ cmd_install_version() {
     local bin_dir="$PERSISTENT_DIR"
     local auto_update="0"
 
+    # Validate CLI option (or default) before loading UCI config
     validate_download_source "$download_source" || return 1
 
     if [ -r /lib/functions.sh ] && [ -f "$CONFIG_FILE" ]; then
@@ -1126,6 +1129,7 @@ cmd_install_version() {
         config_get auto_update settings auto_update "$auto_update"
     fi
 
+    # Re-validate after UCI config may have overridden values
     validate_download_source "$download_source" || return 1
     validate_storage_mode "$storage_mode" || return 1
     validate_auto_update_flag "$auto_update" || return 1

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -53,6 +53,52 @@ require_configured_persistent_bin_dir() {
     require_absolute_path "$bin_dir" "Configured bin_dir"
 }
 
+require_option_value() {
+    local option="$1"
+    local value="${2:-}"
+
+    if [ -z "$value" ]; then
+        log_error "Option ${option} requires a value"
+        return 1
+    fi
+}
+
+validate_download_source() {
+    local source="$1"
+
+    case "$source" in
+        official|small) ;;
+        *)
+            log_error "Invalid download source: ${source}. Expected official or small"
+            return 1
+            ;;
+    esac
+}
+
+validate_storage_mode() {
+    local storage="$1"
+
+    case "$storage" in
+        persistent|ram) ;;
+        *)
+            log_error "Invalid storage mode: ${storage}. Expected persistent or ram"
+            return 1
+            ;;
+    esac
+}
+
+validate_auto_update_flag() {
+    local value="$1"
+
+    case "$value" in
+        0|1) ;;
+        *)
+            log_error "Invalid auto-update value: ${value}. Expected 0 or 1"
+            return 1
+            ;;
+    esac
+}
+
 safe_rm_tree() {
     local path="$1"
     local label="$2"
@@ -931,10 +977,26 @@ cmd_install() {
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --source) opt_source="$2"; shift 2 ;;
-            --storage) opt_storage="$2"; shift 2 ;;
-            --auto-update) opt_auto_update="$2"; shift 2 ;;
-            --bin-dir) opt_bin_dir="$2"; shift 2 ;;
+            --source)
+                require_option_value "$1" "${2:-}" || return 1
+                opt_source="$2"
+                shift 2
+                ;;
+            --storage)
+                require_option_value "$1" "${2:-}" || return 1
+                opt_storage="$2"
+                shift 2
+                ;;
+            --auto-update)
+                require_option_value "$1" "${2:-}" || return 1
+                opt_auto_update="$2"
+                shift 2
+                ;;
+            --bin-dir)
+                require_option_value "$1" "${2:-}" || return 1
+                opt_bin_dir="$2"
+                shift 2
+                ;;
             *) log_error "Unknown option: $1"; return 1 ;;
         esac
     done
@@ -945,6 +1007,10 @@ cmd_install() {
     local persistent_bin_dir="$PERSISTENT_DIR"
     local bin_dir="$PERSISTENT_DIR"
 
+    validate_download_source "$download_source" || return 1
+    validate_storage_mode "$storage_mode" || return 1
+    validate_auto_update_flag "$auto_update" || return 1
+
     if [ -r /lib/functions.sh ] && [ -f "$CONFIG_FILE" ]; then
         . /lib/functions.sh
         config_load tailscale 2>/dev/null || true
@@ -953,6 +1019,10 @@ cmd_install() {
         [ -z "$opt_auto_update" ] && config_get auto_update settings auto_update "$auto_update"
         [ -z "$opt_bin_dir" ] && config_get persistent_bin_dir settings bin_dir "$persistent_bin_dir"
     fi
+
+    validate_download_source "$download_source" || return 1
+    validate_storage_mode "$storage_mode" || return 1
+    validate_auto_update_flag "$auto_update" || return 1
 
     if [ -n "$opt_bin_dir" ]; then
         require_absolute_path "$opt_bin_dir" "--bin-dir" || return 1
@@ -1007,14 +1077,22 @@ cmd_install() {
 }
 
 cmd_install_version() {
-    local target_version="$1"
+    local target_version="${1:-}"
     shift || true
     local opt_source="" opt_bin_dir=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
-            --source) opt_source="$2"; shift 2 ;;
-            --bin-dir) opt_bin_dir="$2"; shift 2 ;;
+            --source)
+                require_option_value "$1" "${2:-}" || return 1
+                opt_source="$2"
+                shift 2
+                ;;
+            --bin-dir)
+                require_option_value "$1" "${2:-}" || return 1
+                opt_bin_dir="$2"
+                shift 2
+                ;;
             *) log_error "Unknown option: $1"; return 1 ;;
         esac
     done
@@ -1037,6 +1115,8 @@ cmd_install_version() {
     local bin_dir="$PERSISTENT_DIR"
     local auto_update="0"
 
+    validate_download_source "$download_source" || return 1
+
     if [ -r /lib/functions.sh ] && [ -f "$CONFIG_FILE" ]; then
         . /lib/functions.sh
         config_load tailscale 2>/dev/null || true
@@ -1045,6 +1125,10 @@ cmd_install_version() {
         [ -z "$opt_bin_dir" ] && config_get persistent_bin_dir settings bin_dir "$persistent_bin_dir"
         config_get auto_update settings auto_update "$auto_update"
     fi
+
+    validate_download_source "$download_source" || return 1
+    validate_storage_mode "$storage_mode" || return 1
+    validate_auto_update_flag "$auto_update" || return 1
 
     if [ -n "$opt_bin_dir" ]; then
         require_absolute_path "$opt_bin_dir" "--bin-dir" || return 1

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -180,28 +180,84 @@ verify_staged_binary() {
 install_staged() {
     local stage_dir="$1"
     local target_dir="$2"
+    local suffix=".$$"
+    local managed_files="tailscale tailscaled tailscale.combined version source"
+    local name cleanup_name deploy_failed=0
 
     mkdir -p "$target_dir"
 
     if [ -f "${stage_dir}/tailscale.combined" ]; then
-        rm -f "${target_dir}/tailscale" "${target_dir}/tailscaled" || return 1
-        mv "${stage_dir}/tailscale.combined" "${target_dir}/tailscale.combined" || return 1
-        chmod +x "${target_dir}/tailscale.combined" || return 1
+        mv "${stage_dir}/tailscale.combined" "${target_dir}/.tailscale.combined.new${suffix}" || return 1
+        chmod +x "${target_dir}/.tailscale.combined.new${suffix}" || {
+            rm -f "${target_dir}/.tailscale.combined.new${suffix}"
+            return 1
+        }
+    else
+        mv "${stage_dir}/tailscaled" "${target_dir}/.tailscaled.new${suffix}" || return 1
+        mv "${stage_dir}/tailscale" "${target_dir}/.tailscale.new${suffix}" || {
+            rm -f "${target_dir}/.tailscaled.new${suffix}"
+            return 1
+        }
+        chmod +x "${target_dir}/.tailscaled.new${suffix}" "${target_dir}/.tailscale.new${suffix}" || {
+            rm -f "${target_dir}/.tailscaled.new${suffix}" "${target_dir}/.tailscale.new${suffix}"
+            return 1
+        }
+    fi
+
+    [ ! -f "${stage_dir}/version" ] || mv "${stage_dir}/version" "${target_dir}/.version.new${suffix}" || {
+        for name in $managed_files; do rm -f "${target_dir}/.${name}.new${suffix}"; done
+        return 1
+    }
+    [ ! -f "${stage_dir}/source" ] || mv "${stage_dir}/source" "${target_dir}/.source.new${suffix}" || {
+        for name in $managed_files; do rm -f "${target_dir}/.${name}.new${suffix}"; done
+        return 1
+    }
+
+    for name in $managed_files; do
+        rm -f "${target_dir}/.${name}.bak${suffix}"
+        if [ -e "${target_dir}/${name}" ] || [ -L "${target_dir}/${name}" ]; then
+            mv -f "${target_dir}/${name}" "${target_dir}/.${name}.bak${suffix}" || {
+                log_error "Failed to back up ${target_dir}/${name}"
+                for cleanup_name in $managed_files; do
+                    rm -f "${target_dir}/.${cleanup_name}.new${suffix}"
+                    if [ -e "${target_dir}/.${cleanup_name}.bak${suffix}" ] || [ -L "${target_dir}/.${cleanup_name}.bak${suffix}" ]; then
+                        mv -f "${target_dir}/.${cleanup_name}.bak${suffix}" "${target_dir}/${cleanup_name}" 2>/dev/null || true
+                    fi
+                done
+                return 1
+            }
+        fi
+    done
+
+    if [ -f "${target_dir}/.tailscale.combined.new${suffix}" ]; then
+        mv "${target_dir}/.tailscale.combined.new${suffix}" "${target_dir}/tailscale.combined" || deploy_failed=1
         (
             cd "$target_dir" || exit 1
             ln -sf "tailscale.combined" "tailscale" || exit 1
             ln -sf "tailscale.combined" "tailscaled" || exit 1
-        ) || return 1
+        ) || deploy_failed=1
     else
-        rm -f "${target_dir}/tailscale.combined" || return 1
-        mv "${stage_dir}/tailscaled" "${target_dir}/tailscaled" || return 1
-        mv "${stage_dir}/tailscale" "${target_dir}/tailscale" || return 1
-        chmod +x "${target_dir}/tailscaled" "${target_dir}/tailscale" || return 1
+        mv "${target_dir}/.tailscaled.new${suffix}" "${target_dir}/tailscaled" || deploy_failed=1
+        mv "${target_dir}/.tailscale.new${suffix}" "${target_dir}/tailscale" || deploy_failed=1
     fi
 
-    # Carry over version and source metadata
-    [ ! -f "${stage_dir}/version" ] || mv "${stage_dir}/version" "${target_dir}/version" || return 1
-    [ ! -f "${stage_dir}/source" ] || mv "${stage_dir}/source" "${target_dir}/source" || return 1
+    [ ! -f "${target_dir}/.version.new${suffix}" ] || mv "${target_dir}/.version.new${suffix}" "${target_dir}/version" || deploy_failed=1
+    [ ! -f "${target_dir}/.source.new${suffix}" ] || mv "${target_dir}/.source.new${suffix}" "${target_dir}/source" || deploy_failed=1
+
+    if [ "$deploy_failed" = "1" ]; then
+        log_error "Failed to install staged files, restoring previous binaries"
+        for name in $managed_files; do
+            rm -f "${target_dir}/${name}" "${target_dir}/.${name}.new${suffix}"
+            if [ -e "${target_dir}/.${name}.bak${suffix}" ] || [ -L "${target_dir}/.${name}.bak${suffix}" ]; then
+                mv -f "${target_dir}/.${name}.bak${suffix}" "${target_dir}/${name}" 2>/dev/null || true
+            fi
+        done
+        return 1
+    fi
+
+    for name in $managed_files; do
+        rm -f "${target_dir}/.${name}.bak${suffix}" "${target_dir}/.${name}.new${suffix}"
+    done
 }
 
 # Download official Tailscale binaries from pkgs.tailscale.com


### PR DESCRIPTION
## Summary
- validate install and install-version option values before mutating installation state
- reject missing values for `--source`, `--storage`, `--auto-update`, and `--bin-dir`
- back up existing managed binaries and metadata before installing staged files
- restore the previous installation when staged file deployment fails
- add regression coverage for option validation and staged install rollback

## Tests
- `make lint`
- `make test`
- `make check-static`
- `make shellcheck`
- `make check-sync`
- `git diff --check`