### PR TITLE
Harden download archive handling

### DIFF
--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -144,9 +144,16 @@ download_repo_file() {
     local url="$1"
     local dest="$2"
     local mode="${3:-644}"
-    local tmp_file="${dest}.tmp.$$"
+    local dest_dir dest_name tmp_file
 
-    mkdir -p "$(dirname "$dest")"
+    dest_dir=$(dirname "$dest")
+    dest_name=$(basename "$dest")
+
+    mkdir -p "$dest_dir"
+    tmp_file=$(mktemp "${dest_dir}/.${dest_name}.XXXXXX" 2>/dev/null) || {
+        log_error "Failed to create temporary file for ${dest}"
+        return 1
+    }
 
     if ! wget -qO "$tmp_file" "$url" 2>/dev/null; then
         rm -f "$tmp_file"

--- a/tests/bats/download/checksum.bats
+++ b/tests/bats/download/checksum.bats
@@ -327,12 +327,18 @@ DOWNLOAD_BASE='https://example.test/stable'
 TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1
 export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
 
+archive_root='${TEST_DIR}/traversal-root'
+mkdir -p \"\$archive_root/safe\"
+printf 'unsafe\n' > \"\$archive_root/evil\"
+(cd \"\$archive_root/safe\" && tar czf '${TEST_DIR}/traversal.tgz' ../evil)
+extraction_marker='${TEST_DIR}/extraction-called'
+
 wget() {
     case \"\$1\" in
         -qO-) return 1 ;;
         --help) return 0 ;;
         -q)
-            printf 'fake archive\n' > \"\$3\"
+            cp '${TEST_DIR}/traversal.tgz' \"\$3\"
             return 0
             ;;
     esac
@@ -342,12 +348,8 @@ wget() {
 
 tar() {
     case \"\$1\" in
-        tzf)
-            printf '../evil\n'
-            return 0
-            ;;
         xzf)
-            echo 'unsafe archive reached extraction' >&2
+            printf 'called\n' > \"\$extraction_marker\"
             return 1
             ;;
     esac
@@ -358,6 +360,170 @@ if download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target' 2>/dev/null;
     echo 'download accepted unsafe archive member'
     exit 1
 fi
+
+[ ! -f \"\$extraction_marker\" ] || { echo 'unsafe archive reached extraction'; exit 1; }
+"
+    assert_success
+}
+
+@test "validate_tar_member_paths rejects unsafe symlink targets" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+archive_root='${TEST_DIR}/symlink-root'
+mkdir -p \"\$archive_root/tailscale_1.2.3_amd64\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscale\"
+ln -s /etc/shadow \"\$archive_root/tailscale_1.2.3_amd64/tailscaled\"
+tar czf '${TEST_DIR}/symlink-target.tgz' -C \"\$archive_root\" tailscale_1.2.3_amd64
+
+if validate_tar_member_paths '${TEST_DIR}/symlink-target.tgz' '${TEST_DIR}/members.list' 2>/dev/null; then
+    echo 'unsafe symlink target accepted'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "download_tailscale_official emergency override still rejects checksum mismatch" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+DOWNLOAD_BASE='https://example.test/stable'
+TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1
+export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
+
+archive_root='${TEST_DIR}/archive-root'
+mkdir -p \"\$archive_root/tailscale_1.2.3_amd64\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscale\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscaled\"
+
+wget() {
+    case \"\$1\" in
+        -qO-)
+            printf '%064d\n' 0
+            return 0
+            ;;
+        --help)
+            return 0
+            ;;
+        -q)
+            tar czf \"\$3\" -C \"\$archive_root\" tailscale_1.2.3_amd64
+            return 0
+            ;;
+    esac
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+if download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target' 2>/dev/null; then
+    echo 'override accepted mismatched checksum'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "download_tailscale_small rejects checksum mismatch" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+SMALL_DOWNLOAD_BASE='https://example.test/releases/download'
+
+get_small_checksum() {
+    printf '%064d\n' 0
+}
+
+archive_root='${TEST_DIR}/small-root'
+mkdir -p \"\$archive_root/tailscale-small_1.2.3_amd64\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale-small_1.2.3_amd64/tailscale.combined\"
+
+wget() {
+    case \"\$1\" in
+        --help)
+            return 0
+            ;;
+        -q)
+            tar czf \"\$3\" -C \"\$archive_root\" tailscale-small_1.2.3_amd64
+            return 0
+            ;;
+    esac
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+if download_tailscale_small '1.2.3' 'amd64' '${TEST_DIR}/target' 2>/dev/null; then
+    echo 'small download accepted mismatched checksum'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "download_tailscale_small rejects path traversal archive members before extraction" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+SMALL_DOWNLOAD_BASE='https://example.test/releases/download'
+TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1
+export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
+
+archive_root='${TEST_DIR}/small-traversal-root'
+mkdir -p \"\$archive_root/safe\"
+printf 'unsafe\n' > \"\$archive_root/evil\"
+(cd \"\$archive_root/safe\" && tar czf '${TEST_DIR}/small-traversal.tgz' ../evil)
+extraction_marker='${TEST_DIR}/small-extraction-called'
+
+get_small_checksum() {
+    return 1
+}
+
+wget() {
+    case \"\$1\" in
+        --help)
+            return 0
+            ;;
+        -q)
+            cp '${TEST_DIR}/small-traversal.tgz' \"\$3\"
+            return 0
+            ;;
+    esac
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+tar() {
+    case \"\$1\" in
+        xzf)
+            printf 'called\n' > \"\$extraction_marker\"
+            return 1
+            ;;
+    esac
+    command tar \"\$@\"
+}
+
+if download_tailscale_small '1.2.3' 'amd64' '${TEST_DIR}/target' 2>/dev/null; then
+    echo 'small download accepted unsafe archive member'
+    exit 1
+fi
+
+[ ! -f \"\$extraction_marker\" ] || { echo 'unsafe small archive reached extraction'; exit 1; }
 "
     assert_success
 }

--- a/tests/bats/download/checksum.bats
+++ b/tests/bats/download/checksum.bats
@@ -65,7 +65,7 @@ fi
     assert_success
 }
 
-@test "verify_checksum skips gracefully when no tools available" {
+@test "verify_checksum rejects missing checksum tools by default" {
     run_in_sh auto "
 set -eu
 export PATH='${STUB_BIN}:${PATH}'
@@ -75,6 +75,29 @@ TAILSCALE_MANAGER_SOURCE_ONLY=1
 LOG_FILE='${TEST_DIR}/tailscale-manager.log'
 
 compute_sha256() { return 1; }
+
+echo 'test data' > '${TEST_DIR}/testfile'
+if verify_checksum '${TEST_DIR}/testfile' 'anything' 2>/dev/null; then
+    echo 'missing checksum tools accepted'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "verify_checksum honors explicit emergency override" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+compute_sha256() { return 1; }
+
+TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1
+export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
 
 echo 'test data' > '${TEST_DIR}/testfile'
 verify_checksum '${TEST_DIR}/testfile' 'anything' 2>/dev/null
@@ -184,6 +207,206 @@ if get_small_checksum '1.98.3' 'tailscale-small_1.98.3_mips64.tgz' 2>/dev/null; 
     echo 'missing arch should fail'
     exit 1
 fi
+"
+    assert_success
+}
+
+@test "download_tailscale_official requires checksum metadata by default" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+DOWNLOAD_BASE='https://example.test/stable'
+
+wget() {
+    case \"\$1\" in
+        -qO-) return 1 ;;
+        --help) return 0 ;;
+        *) echo \"download should not run: \$*\" >&2; return 1 ;;
+    esac
+}
+
+if download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target' 2>/dev/null; then
+    echo 'download accepted missing checksum metadata'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "download_tailscale_official rejects checksum mismatch" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+DOWNLOAD_BASE='https://example.test/stable'
+
+archive_root='${TEST_DIR}/archive-root'
+mkdir -p \"\$archive_root/tailscale_1.2.3_amd64\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscale\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscaled\"
+
+wget() {
+    case \"\$1\" in
+        -qO-)
+            printf '%064d\n' 0
+            return 0
+            ;;
+        --help)
+            return 0
+            ;;
+        -q)
+            tar czf \"\$3\" -C \"\$archive_root\" tailscale_1.2.3_amd64
+            return 0
+            ;;
+    esac
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+if download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target' 2>/dev/null; then
+    echo 'download accepted mismatched checksum'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "download_tailscale_official allows explicit emergency checksum override" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+DOWNLOAD_BASE='https://example.test/stable'
+TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1
+export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
+
+archive_root='${TEST_DIR}/archive-root'
+mkdir -p \"\$archive_root/tailscale_1.2.3_amd64\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscale\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscaled\"
+
+wget() {
+    case \"\$1\" in
+        -qO-) return 1 ;;
+        --help) return 0 ;;
+        -q)
+            tar czf \"\$3\" -C \"\$archive_root\" tailscale_1.2.3_amd64
+            return 0
+            ;;
+    esac
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target'
+[ -f '${TEST_DIR}/target/tailscale' ] || { echo 'tailscale missing'; exit 1; }
+[ -f '${TEST_DIR}/target/tailscaled' ] || { echo 'tailscaled missing'; exit 1; }
+"
+    assert_success
+}
+
+@test "download_tailscale_official rejects path traversal archive members" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+DOWNLOAD_BASE='https://example.test/stable'
+TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1
+export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
+
+wget() {
+    case \"\$1\" in
+        -qO-) return 1 ;;
+        --help) return 0 ;;
+        -q)
+            printf 'fake archive\n' > \"\$3\"
+            return 0
+            ;;
+    esac
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+tar() {
+    case \"\$1\" in
+        tzf)
+            printf '../evil\n'
+            return 0
+            ;;
+        xzf)
+            echo 'unsafe archive reached extraction' >&2
+            return 1
+            ;;
+    esac
+    command tar \"\$@\"
+}
+
+if download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target' 2>/dev/null; then
+    echo 'download accepted unsafe archive member'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "download_tailscale_official uses isolated temp paths for concurrent downloads" {
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+DOWNLOAD_BASE='https://example.test/stable'
+TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1
+export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
+
+archive_root='${TEST_DIR}/archive-root'
+mkdir -p \"\$archive_root/tailscale_1.2.3_amd64\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscale\"
+printf '#!/bin/sh\n' > \"\$archive_root/tailscale_1.2.3_amd64/tailscaled\"
+dest_log='${TEST_DIR}/download-dests.log'
+
+wget() {
+    case \"\$1\" in
+        -qO-) return 1 ;;
+        --help) return 0 ;;
+        -q)
+            printf '%s\n' \"\$3\" >> \"\$dest_log\"
+            sleep 1
+            tar czf \"\$3\" -C \"\$archive_root\" tailscale_1.2.3_amd64
+            return 0
+            ;;
+    esac
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target-a' &
+pid_a=\$!
+download_tailscale_official '1.2.3' 'amd64' '${TEST_DIR}/target-b' &
+pid_b=\$!
+wait \"\$pid_a\"
+wait \"\$pid_b\"
+
+[ -f '${TEST_DIR}/target-a/tailscale' ] || { echo 'target-a missing'; exit 1; }
+[ -f '${TEST_DIR}/target-b/tailscale' ] || { echo 'target-b missing'; exit 1; }
+
+count=\$(sort -u \"\$dest_log\" | wc -l | tr -d ' ')
+[ \"\$count\" = '2' ] || { echo 'download temp paths collided'; cat \"\$dest_log\"; exit 1; }
 "
     assert_success
 }

--- a/tests/bats/download/checksum.bats
+++ b/tests/bats/download/checksum.bats
@@ -330,7 +330,17 @@ export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
 archive_root='${TEST_DIR}/traversal-root'
 mkdir -p \"\$archive_root/safe\"
 printf 'unsafe\n' > \"\$archive_root/evil\"
-(cd \"\$archive_root/safe\" && tar czf '${TEST_DIR}/traversal.tgz' ../evil)
+python3 - '${TEST_DIR}/traversal.tgz' <<'PY'
+import io
+import sys
+import tarfile
+
+data = b'unsafe\n'
+info = tarfile.TarInfo('../evil')
+info.size = len(data)
+with tarfile.open(sys.argv[1], 'w:gz') as tar:
+    tar.addfile(info, io.BytesIO(data))
+PY
 extraction_marker='${TEST_DIR}/extraction-called'
 
 wget() {
@@ -487,7 +497,17 @@ export TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD
 archive_root='${TEST_DIR}/small-traversal-root'
 mkdir -p \"\$archive_root/safe\"
 printf 'unsafe\n' > \"\$archive_root/evil\"
-(cd \"\$archive_root/safe\" && tar czf '${TEST_DIR}/small-traversal.tgz' ../evil)
+python3 - '${TEST_DIR}/small-traversal.tgz' <<'PY'
+import io
+import sys
+import tarfile
+
+data = b'unsafe\n'
+info = tarfile.TarInfo('../evil')
+info.size = len(data)
+with tarfile.open(sys.argv[1], 'w:gz') as tar:
+    tar.addfile(info, io.BytesIO(data))
+PY
 extraction_marker='${TEST_DIR}/small-extraction-called'
 
 get_small_checksum() {

--- a/tests/bats/selfupdate/bundle.bats
+++ b/tests/bats/selfupdate/bundle.bats
@@ -154,7 +154,17 @@ export MGMT_BUNDLE_URL MGMT_BUNDLE_SHA256_URL
 archive_root='${TEST_DIR}/mgmt-traversal-root'
 mkdir -p \"\$archive_root/safe\"
 printf 'unsafe\n' > \"\$archive_root/evil\"
-(cd \"\$archive_root/safe\" && tar czf '${TEST_DIR}/mgmt-traversal.tgz' ../evil)
+python3 - '${TEST_DIR}/mgmt-traversal.tgz' <<'PY'
+import io
+import sys
+import tarfile
+
+data = b'unsafe\n'
+info = tarfile.TarInfo('../evil')
+info.size = len(data)
+with tarfile.open(sys.argv[1], 'w:gz') as tar:
+    tar.addfile(info, io.BytesIO(data))
+PY
 sha256sum '${TEST_DIR}/mgmt-traversal.tgz' | awk '{print \$1}' > '${TEST_DIR}/mgmt-traversal.sha256'
 extraction_marker='${TEST_DIR}/mgmt-extraction-called'
 

--- a/tests/bats/selfupdate/bundle.bats
+++ b/tests/bats/selfupdate/bundle.bats
@@ -73,14 +73,11 @@ export MANAGER_BIN_PATH COMMON_LIB_PATH COMMON_LIB_URL LIB_DIR INIT_SCRIPT CRON_
 
 wget() {
     if [ \"\$1\" = '-qO' ] && printf '%s' \"\$2\" | grep -q 'tar.gz.sha256'; then
-        sha256sum \"\${2%.sha256.*}.\${2##*.sha256.}\" 2>/dev/null | awk '{print \$1}' > \"\$2\" || true
-        # Fall back: compute on the .tar.gz temp
-        local tarball=\"/tmp/tailscale-mgmt.tar.gz.\$\$\"
-        sha256sum \"\$tarball\" 2>/dev/null | awk '{print \$1}' > \"\$2\" || true
+        cat '${TEST_DIR}/management-bundle.sha256' > \"\$2\"
         return 0
     elif [ \"\$1\" = '-qO' ] && printf '%s' \"\$2\" | grep -q 'tar.gz'; then
         tar czf \"\$2\" -C '${STAGING_ROOT}' .
-        sha256sum \"\$2\" | awk '{print \$1}' > \"\$2.sha256.tmp\"
+        sha256sum \"\$2\" | awk '{print \$1}' > '${TEST_DIR}/management-bundle.sha256'
         return 0
     fi
     echo \"unexpected wget invocation: \$*\" >&2

--- a/tests/bats/selfupdate/bundle.bats
+++ b/tests/bats/selfupdate/bundle.bats
@@ -98,3 +98,99 @@ do_self_update --non-interactive >/dev/null 2>&1 || {
 " < /dev/null
     assert_success
 }
+
+@test "do_self_update: rejects checksum mismatch" {
+    run_in_sh auto "
+set -eu
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+export LIB_DIR TAILSCALE_MANAGER_SOURCE_ONLY
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+MGMT_BUNDLE_URL='https://example.test/mgmt/latest/tailscale-mgmt.tar.gz'
+MGMT_BUNDLE_SHA256_URL='https://example.test/mgmt/latest/tailscale-mgmt.tar.gz.sha256'
+export MGMT_BUNDLE_URL MGMT_BUNDLE_SHA256_URL
+
+deploy_management_bundle() {
+    printf 'called\n' > '${TEST_DIR}/deploy-called'
+}
+
+wget() {
+    if [ \"\$1\" = '-qO' ] && printf '%s' \"\$2\" | grep -q 'tar.gz.sha256'; then
+        printf '%064d\n' 0 > \"\$2\"
+        return 0
+    elif [ \"\$1\" = '-qO' ] && printf '%s' \"\$2\" | grep -q 'tar.gz'; then
+        printf 'bundle\n' > \"\$2\"
+        return 0
+    fi
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+if do_self_update --non-interactive >/dev/null 2>&1; then
+    echo 'self-update accepted checksum mismatch'
+    exit 1
+fi
+
+[ ! -f '${TEST_DIR}/deploy-called' ] || { echo 'deploy should not run'; exit 1; }
+"
+    assert_success
+}
+
+@test "do_self_update: rejects path traversal archive members before extraction" {
+    run_in_sh auto "
+set -eu
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+export LIB_DIR TAILSCALE_MANAGER_SOURCE_ONLY
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+MGMT_BUNDLE_URL='https://example.test/mgmt/latest/tailscale-mgmt.tar.gz'
+MGMT_BUNDLE_SHA256_URL='https://example.test/mgmt/latest/tailscale-mgmt.tar.gz.sha256'
+export MGMT_BUNDLE_URL MGMT_BUNDLE_SHA256_URL
+
+archive_root='${TEST_DIR}/mgmt-traversal-root'
+mkdir -p \"\$archive_root/safe\"
+printf 'unsafe\n' > \"\$archive_root/evil\"
+(cd \"\$archive_root/safe\" && tar czf '${TEST_DIR}/mgmt-traversal.tgz' ../evil)
+sha256sum '${TEST_DIR}/mgmt-traversal.tgz' | awk '{print \$1}' > '${TEST_DIR}/mgmt-traversal.sha256'
+extraction_marker='${TEST_DIR}/mgmt-extraction-called'
+
+deploy_management_bundle() {
+    printf 'called\n' > '${TEST_DIR}/deploy-called'
+}
+
+wget() {
+    if [ \"\$1\" = '-qO' ] && printf '%s' \"\$2\" | grep -q 'tar.gz.sha256'; then
+        cat '${TEST_DIR}/mgmt-traversal.sha256' > \"\$2\"
+        return 0
+    elif [ \"\$1\" = '-qO' ] && printf '%s' \"\$2\" | grep -q 'tar.gz'; then
+        cp '${TEST_DIR}/mgmt-traversal.tgz' \"\$2\"
+        return 0
+    fi
+    echo \"unexpected wget invocation: \$*\" >&2
+    return 1
+}
+
+tar() {
+    case \"\$1\" in
+        xzf)
+            printf 'called\n' > \"\$extraction_marker\"
+            return 1
+            ;;
+    esac
+    command tar \"\$@\"
+}
+
+if do_self_update --non-interactive >/dev/null 2>&1; then
+    echo 'self-update accepted unsafe archive member'
+    exit 1
+fi
+
+[ ! -f \"\$extraction_marker\" ] || { echo 'unsafe management bundle reached extraction'; exit 1; }
+[ ! -f '${TEST_DIR}/deploy-called' ] || { echo 'deploy should not run'; exit 1; }
+"
+    assert_success
+}

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -466,8 +466,9 @@ do_update() {
         esac
     fi
 
-    # Stage: download new version to a temp directory
-    local stage_dir="/tmp/tailscale_staged_$$"
+    # Stage: download new version to a private temp directory
+    local stage_dir
+    stage_dir=$(create_tailscale_temp_dir "tailscale-staged") || return 1
     log_info "Downloading v${latest_version} to staging area..."
     stage_tailscale "$latest_version" "$arch" "$stage_dir" || {
         log_error "Download failed"

--- a/usr/lib/tailscale/deploy.sh
+++ b/usr/lib/tailscale/deploy.sh
@@ -242,9 +242,13 @@ managed_sync_is_current() {
 }
 
 mark_managed_sync_version() {
-    local tmp_file="${MANAGED_SYNC_VERSION_FILE}.tmp.$$"
+    local sync_dir sync_name tmp_file
 
-    mkdir -p "$(dirname "$MANAGED_SYNC_VERSION_FILE")" || return 1
+    sync_dir=$(dirname "$MANAGED_SYNC_VERSION_FILE")
+    sync_name=$(basename "$MANAGED_SYNC_VERSION_FILE")
+
+    mkdir -p "$sync_dir" || return 1
+    tmp_file=$(mktemp "${sync_dir}/.${sync_name}.XXXXXX" 2>/dev/null) || return 1
     printf '%s\n' "$VERSION" > "$tmp_file" || {
         rm -f "$tmp_file"
         return 1

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -32,10 +32,24 @@ checksum_emergency_override_enabled() {
     esac
 }
 
+is_safe_tar_path() {
+    local path="$1"
+
+    case "$path" in
+        ""|/*|../*|*/../*|*/..|..)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
 validate_tar_member_paths() {
     local tarball="$1"
     local list_file="$2"
-    local member
+    local verbose_file="${list_file}.verbose"
+    local member line target
 
     if ! tar tzf "$tarball" > "$list_file" 2>/dev/null; then
         log_error "Failed to list archive contents"
@@ -43,13 +57,43 @@ validate_tar_member_paths() {
     fi
 
     while IFS= read -r member; do
-        case "$member" in
-            ""|/*|../*|*/../*|*/..|..)
-                log_error "Archive contains unsafe path: ${member}"
+        if ! is_safe_tar_path "$member"; then
+            log_error "Archive contains unsafe path: ${member}"
+            return 1
+        fi
+    done < "$list_file"
+
+    if ! tar tvzf "$tarball" > "$verbose_file" 2>/dev/null; then
+        log_error "Failed to list archive details"
+        return 1
+    fi
+
+    while IFS= read -r line; do
+        case "$line" in
+            l*" -> "*)
+                target=${line##* -> }
+                if ! is_safe_tar_path "$target"; then
+                    log_error "Archive contains unsafe link target: ${target}"
+                    return 1
+                fi
+                ;;
+            l*)
+                log_error "Failed to parse archive symlink target"
+                return 1
+                ;;
+            h*" link to "*)
+                target=${line##* link to }
+                if ! is_safe_tar_path "$target"; then
+                    log_error "Archive contains unsafe link target: ${target}"
+                    return 1
+                fi
+                ;;
+            h*)
+                log_error "Failed to parse archive hardlink target"
                 return 1
                 ;;
         esac
-    done < "$list_file"
+    done < "$verbose_file"
 
     return 0
 }

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -464,6 +464,7 @@ download_tailscale_small() {
         ln -sf "tailscale.combined" "tailscaled"
     ) || {
         log_error "Failed to enter ${target_dir} to create symlinks"
+        rm -rf "$tmp_dir"
         return 1
     }
 

--- a/usr/lib/tailscale/download.sh
+++ b/usr/lib/tailscale/download.sh
@@ -9,6 +9,51 @@
 # Required functions (from entry script):
 #   log_info(), log_error(), log_warn(), download_repo_file()
 
+create_tailscale_temp_dir() {
+    local prefix="${1:-tailscale}"
+    local base="${TMPDIR:-/tmp}"
+    local tmp_dir=""
+
+    tmp_dir=$(mktemp -d "${base%/}/${prefix}.XXXXXX" 2>/dev/null) \
+        || tmp_dir=$(mktemp -d -t "${prefix}.XXXXXX" 2>/dev/null) \
+        || {
+            log_error "Failed to create private temporary directory"
+            return 1
+        }
+
+    chmod 700 "$tmp_dir" 2>/dev/null || true
+    printf '%s\n' "$tmp_dir"
+}
+
+checksum_emergency_override_enabled() {
+    case "${TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD:-}" in
+        1|true|TRUE|yes|YES) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_tar_member_paths() {
+    local tarball="$1"
+    local list_file="$2"
+    local member
+
+    if ! tar tzf "$tarball" > "$list_file" 2>/dev/null; then
+        log_error "Failed to list archive contents"
+        return 1
+    fi
+
+    while IFS= read -r member; do
+        case "$member" in
+            ""|/*|../*|*/../*|*/..|..)
+                log_error "Archive contains unsafe path: ${member}"
+                return 1
+                ;;
+        esac
+    done < "$list_file"
+
+    return 0
+}
+
 # Compute SHA-256 hash of a file
 # Uses sha256sum (coreutils/busybox) or openssl as fallback
 compute_sha256() {
@@ -31,8 +76,12 @@ verify_checksum() {
 
     local actual
     actual=$(compute_sha256 "$file") || {
-        log_warn "sha256 verification skipped: no sha256sum or openssl available"
-        return 0
+        if checksum_emergency_override_enabled; then
+            log_warn "Emergency checksum override enabled: sha256 tool is unavailable"
+            return 0
+        fi
+        log_error "sha256 verification requires sha256sum or openssl"
+        return 1
     }
 
     if [ "$actual" != "$expected" ]; then
@@ -273,37 +322,48 @@ download_tailscale_official() {
 
     local filename="tailscale_${version}_${official_arch}.tgz"
     local url="${DOWNLOAD_BASE}/${filename}"
-    local tmp_dir="/tmp/tailscale_download_$$"
-    local tarball="/tmp/${filename}"
+    local tmp_dir
+    local tarball
+
+    tmp_dir=$(create_tailscale_temp_dir "tailscale-download") || return 1
+    tarball="${tmp_dir}/${filename}"
 
     log_info "Downloading Tailscale v${version} for ${arch} (official)..."
     log_info "URL: $url"
 
     local expected_checksum
     expected_checksum=$(get_official_checksum "$url") || {
-        log_warn "Could not fetch checksum from ${url}.sha256"
+        if checksum_emergency_override_enabled; then
+            log_warn "Emergency checksum override enabled: could not fetch ${url}.sha256"
+            expected_checksum=""
+        else
+            log_error "Could not fetch checksum from ${url}.sha256"
+            rm -rf "$tmp_dir"
+            return 1
+        fi
     }
 
     local wget_progress
     wget_progress=$(get_wget_progress_option)
     if ! wget "$wget_progress" -O "$tarball" "$url" 2>&1; then
         log_error "Download failed"
-        rm -f "$tarball"
+        rm -rf "$tmp_dir"
         return 1
     fi
 
-    if [ -n "$expected_checksum" ]; then
-        if ! verify_checksum "$tarball" "$expected_checksum"; then
-            rm -f "$tarball"
-            return 1
-        fi
+    if [ -n "$expected_checksum" ] && ! verify_checksum "$tarball" "$expected_checksum"; then
+        rm -rf "$tmp_dir"
+        return 1
     fi
 
     log_info "Extracting..."
-    mkdir -p "$tmp_dir"
+    if ! validate_tar_member_paths "$tarball" "${tmp_dir}/archive-members.list"; then
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
     if ! tar xzf "$tarball" -C "$tmp_dir" 2>&1; then
         log_error "Extraction failed"
-        rm -f "$tarball"
         rm -rf "$tmp_dir"
         return 1
     fi
@@ -311,7 +371,6 @@ download_tailscale_official() {
     local extracted_dir="${tmp_dir}/tailscale_${version}_${official_arch}"
     if [ ! -f "${extracted_dir}/tailscaled" ] || [ ! -f "${extracted_dir}/tailscale" ]; then
         log_error "Required binaries not found in archive"
-        rm -f "$tarball"
         rm -rf "$tmp_dir"
         return 1
     fi
@@ -325,7 +384,6 @@ download_tailscale_official() {
     echo "$version" > "${target_dir}/version"
     echo "official" > "${target_dir}/source"
 
-    rm -f "$tarball"
     rm -rf "$tmp_dir"
 
     log_info "Successfully installed Tailscale v${version}"
@@ -340,37 +398,48 @@ download_tailscale_small() {
 
     local filename="tailscale-small_${version}_${arch}.tgz"
     local url="${SMALL_DOWNLOAD_BASE}/v${version}/${filename}"
-    local tmp_dir="/tmp/tailscale_download_$$"
-    local tarball="/tmp/${filename}"
+    local tmp_dir
+    local tarball
+
+    tmp_dir=$(create_tailscale_temp_dir "tailscale-download") || return 1
+    tarball="${tmp_dir}/${filename}"
 
     log_info "Downloading Tailscale v${version} for ${arch} (small/compressed)..."
     log_info "URL: $url"
 
     local expected_checksum
     expected_checksum=$(get_small_checksum "$version" "$filename") || {
-        log_warn "Could not fetch checksum from GitHub API"
+        if checksum_emergency_override_enabled; then
+            log_warn "Emergency checksum override enabled: could not fetch checksum from GitHub API"
+            expected_checksum=""
+        else
+            log_error "Could not fetch checksum from GitHub API"
+            rm -rf "$tmp_dir"
+            return 1
+        fi
     }
 
     local wget_progress
     wget_progress=$(get_wget_progress_option)
     if ! wget "$wget_progress" -O "$tarball" "$url" 2>&1; then
         log_error "Download failed"
-        rm -f "$tarball"
+        rm -rf "$tmp_dir"
         return 1
     fi
 
-    if [ -n "$expected_checksum" ]; then
-        if ! verify_checksum "$tarball" "$expected_checksum"; then
-            rm -f "$tarball"
-            return 1
-        fi
+    if [ -n "$expected_checksum" ] && ! verify_checksum "$tarball" "$expected_checksum"; then
+        rm -rf "$tmp_dir"
+        return 1
     fi
 
     log_info "Extracting..."
-    mkdir -p "$tmp_dir"
+    if ! validate_tar_member_paths "$tarball" "${tmp_dir}/archive-members.list"; then
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
     if ! tar xzf "$tarball" -C "$tmp_dir" 2>&1; then
         log_error "Extraction failed"
-        rm -f "$tarball"
         rm -rf "$tmp_dir"
         return 1
     fi
@@ -379,7 +448,6 @@ download_tailscale_small() {
 
     if [ ! -f "${extracted_dir}/tailscale.combined" ]; then
         log_error "Combined binary not found in archive"
-        rm -f "$tarball"
         rm -rf "$tmp_dir"
         return 1
     fi
@@ -402,7 +470,6 @@ download_tailscale_small() {
     echo "$version" > "${target_dir}/version"
     echo "small" > "${target_dir}/source"
 
-    rm -f "$tarball"
     rm -rf "$tmp_dir"
 
     log_info "Successfully installed Tailscale v${version} (small)"

--- a/usr/lib/tailscale/json.sh
+++ b/usr/lib/tailscale/json.sh
@@ -85,12 +85,16 @@ _get_display_name() {
 # Outputs comma-separated peer JSON objects (no surrounding brackets).
 _extract_peers_jsonfilter() {
     local ts_file="$1"
-    local _tmp="/tmp/.ts-peers.$$.d"
-    local _objects="$_tmp/objects"
+    local _tmp
+    local _objects
     local first=1
     local peer_json dns host ip os online exit_n exit_opt rx tx seen
 
-    mkdir -p "$_tmp"
+    _tmp=$(mktemp -d "${TMPDIR:-/tmp}/ts-peers.XXXXXX" 2>/dev/null) \
+        || _tmp=$(mktemp -d -t "ts-peers.XXXXXX" 2>/dev/null) \
+        || return 0
+    chmod 700 "$_tmp" 2>/dev/null || true
+    _objects="$_tmp/objects"
 
     jsonfilter -i "$ts_file" -e '@.Peer[*]' > "$_objects" 2>/dev/null || true
 
@@ -205,7 +209,14 @@ cmd_json_status() {
         ts_json=$(tailscale status --json 2>/dev/null) || true
 
         if [ -n "$ts_json" ]; then
-            local ts_file="/tmp/.ts-status.$$.json"
+            local ts_tmp=""
+            local ts_file=""
+            ts_tmp=$(mktemp -d "${TMPDIR:-/tmp}/ts-status.XXXXXX" 2>/dev/null) \
+                || ts_tmp=$(mktemp -d -t "ts-status.XXXXXX" 2>/dev/null) \
+                || ts_tmp=""
+            [ -n "$ts_tmp" ] || return 1
+            chmod 700 "$ts_tmp" 2>/dev/null || true
+            ts_file="${ts_tmp}/status.json"
             printf '%s' "$ts_json" > "$ts_file"
 
             if command -v jsonfilter >/dev/null 2>&1; then
@@ -216,7 +227,7 @@ cmd_json_status() {
                 _parse_status_sed "$ts_file"
             fi
 
-            rm -f "$ts_file"
+            rm -rf "$ts_tmp"
         fi
     fi
 

--- a/usr/lib/tailscale/json.sh
+++ b/usr/lib/tailscale/json.sh
@@ -92,7 +92,7 @@ _extract_peers_jsonfilter() {
 
     _tmp=$(mktemp -d "${TMPDIR:-/tmp}/ts-peers.XXXXXX" 2>/dev/null) \
         || _tmp=$(mktemp -d -t "ts-peers.XXXXXX" 2>/dev/null) \
-        || return 0
+        || return 1
     chmod 700 "$_tmp" 2>/dev/null || true
     _objects="$_tmp/objects"
 

--- a/usr/lib/tailscale/selfupdate.sh
+++ b/usr/lib/tailscale/selfupdate.sh
@@ -7,6 +7,7 @@
 #
 # Required functions:
 #   log_info(), log_error(), log_warn()
+#   create_tailscale_temp_dir(), validate_tar_member_paths() (from download.sh)
 #   version_lt() (from version.sh)
 #   deploy_management_bundle(), managed_sync_is_current() (from deploy.sh)
 
@@ -25,53 +26,6 @@ download_management_bundle_file() {
         log_error "Downloaded bundle file is empty: ${url}"
         return 1
     }
-
-    return 0
-}
-
-create_management_temp_dir() {
-    if command -v create_tailscale_temp_dir >/dev/null 2>&1; then
-        create_tailscale_temp_dir "tailscale-mgmt"
-        return $?
-    fi
-
-    local base="${TMPDIR:-/tmp}"
-    local tmp_dir=""
-
-    tmp_dir=$(mktemp -d "${base%/}/tailscale-mgmt.XXXXXX" 2>/dev/null) \
-        || tmp_dir=$(mktemp -d -t "tailscale-mgmt.XXXXXX" 2>/dev/null) \
-        || {
-            log_error "Failed to create private temporary directory"
-            return 1
-        }
-
-    chmod 700 "$tmp_dir" 2>/dev/null || true
-    printf '%s\n' "$tmp_dir"
-}
-
-validate_management_tar_member_paths() {
-    if command -v validate_tar_member_paths >/dev/null 2>&1; then
-        validate_tar_member_paths "$@"
-        return $?
-    fi
-
-    local tarball="$1"
-    local list_file="$2"
-    local member
-
-    if ! tar tzf "$tarball" > "$list_file" 2>/dev/null; then
-        log_error "Failed to list archive contents"
-        return 1
-    fi
-
-    while IFS= read -r member; do
-        case "$member" in
-            ""|/*|../*|*/../*|*/..|..)
-                log_error "Archive contains unsafe path: ${member}"
-                return 1
-                ;;
-        esac
-    done < "$list_file"
 
     return 0
 }
@@ -262,7 +216,7 @@ do_self_update() {
     local staging_dir
     local bundle_version=""
 
-    tmp_dir=$(create_management_temp_dir) || return 1
+    tmp_dir=$(create_tailscale_temp_dir "tailscale-mgmt") || return 1
     tmp_bundle="${tmp_dir}/tailscale-mgmt.tar.gz"
     tmp_checksum="${tmp_dir}/tailscale-mgmt.tar.gz.sha256"
     staging_dir="${tmp_dir}/staging"
@@ -290,7 +244,7 @@ do_self_update() {
         return 1
     }
 
-    if ! validate_management_tar_member_paths "$tmp_bundle" "${tmp_dir}/archive-members.list"; then
+    if ! validate_tar_member_paths "$tmp_bundle" "${tmp_dir}/archive-members.list"; then
         rm -rf "$tmp_dir"
         return 1
     fi

--- a/usr/lib/tailscale/selfupdate.sh
+++ b/usr/lib/tailscale/selfupdate.sh
@@ -29,6 +29,53 @@ download_management_bundle_file() {
     return 0
 }
 
+create_management_temp_dir() {
+    if command -v create_tailscale_temp_dir >/dev/null 2>&1; then
+        create_tailscale_temp_dir "tailscale-mgmt"
+        return $?
+    fi
+
+    local base="${TMPDIR:-/tmp}"
+    local tmp_dir=""
+
+    tmp_dir=$(mktemp -d "${base%/}/tailscale-mgmt.XXXXXX" 2>/dev/null) \
+        || tmp_dir=$(mktemp -d -t "tailscale-mgmt.XXXXXX" 2>/dev/null) \
+        || {
+            log_error "Failed to create private temporary directory"
+            return 1
+        }
+
+    chmod 700 "$tmp_dir" 2>/dev/null || true
+    printf '%s\n' "$tmp_dir"
+}
+
+validate_management_tar_member_paths() {
+    if command -v validate_tar_member_paths >/dev/null 2>&1; then
+        validate_tar_member_paths "$@"
+        return $?
+    fi
+
+    local tarball="$1"
+    local list_file="$2"
+    local member
+
+    if ! tar tzf "$tarball" > "$list_file" 2>/dev/null; then
+        log_error "Failed to list archive contents"
+        return 1
+    fi
+
+    while IFS= read -r member; do
+        case "$member" in
+            ""|/*|../*|*/../*|*/..|..)
+                log_error "Archive contains unsafe path: ${member}"
+                return 1
+                ;;
+        esac
+    done < "$list_file"
+
+    return 0
+}
+
 verify_management_bundle_checksum() {
     local bundle_path="$1"
     local checksum_path="$2"
@@ -209,52 +256,62 @@ check_script_update() {
 
 # Perform script self-update via management bundle deploy
 do_self_update() {
-    local tmp_bundle="/tmp/tailscale-mgmt.tar.gz.$$"
-    local tmp_checksum="/tmp/tailscale-mgmt.tar.gz.sha256.$$"
-    local staging_dir="/tmp/tailscale-mgmt-staging.$$"
+    local tmp_dir
+    local tmp_bundle
+    local tmp_checksum
+    local staging_dir
     local bundle_version=""
+
+    tmp_dir=$(create_management_temp_dir) || return 1
+    tmp_bundle="${tmp_dir}/tailscale-mgmt.tar.gz"
+    tmp_checksum="${tmp_dir}/tailscale-mgmt.tar.gz.sha256"
+    staging_dir="${tmp_dir}/staging"
 
     echo ""
     log_info "Downloading management bundle..."
 
-    download_management_bundle_file "$MGMT_BUNDLE_URL" "$tmp_bundle" || return 1
+    download_management_bundle_file "$MGMT_BUNDLE_URL" "$tmp_bundle" || {
+        rm -rf "$tmp_dir"
+        return 1
+    }
     download_management_bundle_file "$MGMT_BUNDLE_SHA256_URL" "$tmp_checksum" || {
-        rm -f "$tmp_bundle"
+        rm -rf "$tmp_dir"
         return 1
     }
 
     verify_management_bundle_checksum "$tmp_bundle" "$tmp_checksum" || {
-        rm -f "$tmp_bundle" "$tmp_checksum"
+        rm -rf "$tmp_dir"
         return 1
     }
 
     mkdir -p "$staging_dir" || {
-        rm -f "$tmp_bundle" "$tmp_checksum"
+        rm -rf "$tmp_dir"
         log_error "Failed to create management bundle staging directory"
         return 1
     }
 
+    if ! validate_management_tar_member_paths "$tmp_bundle" "${tmp_dir}/archive-members.list"; then
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
     if ! tar xzf "$tmp_bundle" -C "$staging_dir" 2>/dev/null; then
-        rm -rf "$staging_dir"
-        rm -f "$tmp_bundle" "$tmp_checksum"
+        rm -rf "$tmp_dir"
         log_error "Failed to unpack management bundle"
         return 1
     fi
 
     bundle_version=$(validate_management_bundle "$staging_dir") || {
-        rm -rf "$staging_dir"
-        rm -f "$tmp_bundle" "$tmp_checksum"
+        rm -rf "$tmp_dir"
         return 1
     }
 
     deploy_management_bundle "$staging_dir" "$bundle_version" || {
-        rm -rf "$staging_dir"
-        rm -f "$tmp_bundle" "$tmp_checksum"
+        rm -rf "$tmp_dir"
         return 1
     }
 
-    rm -rf "$staging_dir"
-    rm -f "$tmp_bundle" "$tmp_checksum"
+    rm -rf "$tmp_dir"
 
     log_info "Script updated to v${bundle_version}"
     echo ""

--- a/usr/lib/tailscale/version.sh
+++ b/usr/lib/tailscale/version.sh
@@ -237,8 +237,15 @@ version_lt() {
 # Get remote script version from the management bundle metadata
 get_remote_script_version() {
     local remote_version
-    local tmp_file="/tmp/.script-version-check.$$"
+    local tmp_dir
+    local tmp_file
     local timeout_secs=5
+
+    tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/tailscale-version.XXXXXX" 2>/dev/null) \
+        || tmp_dir=$(mktemp -d -t "tailscale-version.XXXXXX" 2>/dev/null) \
+        || return 1
+    chmod 700 "$tmp_dir" 2>/dev/null || true
+    tmp_file="${tmp_dir}/VERSION"
 
     (wget -qO- "$MGMT_VERSION_URL" 2>/dev/null | head -20 > "$tmp_file") &
     local pid=$!
@@ -250,7 +257,7 @@ get_remote_script_version() {
         if [ "$count" -ge "$timeout_secs" ]; then
             kill "$pid" 2>/dev/null
             wait "$pid" 2>/dev/null
-            rm -f "$tmp_file"
+            rm -rf "$tmp_dir"
             return 1
         fi
     done
@@ -258,8 +265,9 @@ get_remote_script_version() {
 
     if [ -f "$tmp_file" ]; then
         remote_version=$(sed -n '1p' "$tmp_file")
-        rm -f "$tmp_file"
     fi
+
+    rm -rf "$tmp_dir"
 
     if [ -z "$remote_version" ]; then
         return 1


### PR DESCRIPTION
## TL;DR

Download and management-bundle installation now require checksum metadata and successful SHA-256 verification before archive extraction. Downloaded archives are inspected before unpacking, including member paths and link targets, and temporary artifacts are created under private `mktemp` locations.

## Files to review

| File | Why it matters |
| --- | --- |
| `usr/lib/tailscale/download.sh` | Enforces checksum verification, private download temp directories, tar member path validation, and link target validation for official and small binaries. |
| `usr/lib/tailscale/selfupdate.sh` | Applies the shared temp-directory and archive validation helpers to management bundle self-updates. |
| `usr/lib/tailscale/commands.sh` | Moves staged update downloads into private `mktemp` directories. |
| `tailscale-manager.sh`, `usr/lib/tailscale/version.sh`, `usr/lib/tailscale/deploy.sh`, `usr/lib/tailscale/json.sh` | Replaces predictable temporary files used by bootstrap, version checks, managed sync markers, and JSON parsing. |
| `tests/bats/download/checksum.bats`, `tests/bats/selfupdate/bundle.bats` | Covers checksum failures, missing checksum tools, explicit emergency override, unsafe archive paths, unsafe link targets, small binary downloads, and management bundle failures. |

## Why

The download path used predictable temporary locations and allowed installation to continue after checksum metadata lookup failed. Checksum verification also treated unavailable checksum tooling as a successful verification path. Archive extraction occurred before member paths were inspected, and link targets inside archives needed the same safety checks as member names.

## How

- Added private `mktemp` directory helpers for download, update staging, self-update, version check, JSON parsing, and managed sync writes.
- Required checksum metadata and SHA-256 verification for downloaded binary archives.
- Added `TAILSCALE_ALLOW_UNVERIFIED_DOWNLOAD=1` as an explicit emergency override for checksum metadata or checksum tooling failures.
- Added tar member path and link target validation before extracting official, small, and management bundle archives.
- Reused the shared download archive helpers from self-update code to keep validation behavior aligned.

## Tests

- `make ci`
- Targeted Bats coverage for checksum mismatch, missing checksum tools, checksum metadata failures, emergency override behavior, archive path traversal, unsafe link targets, small downloads, management bundle failures, and concurrent temp paths.