### PR TITLE
Harden LuCI RPC tasks and cron reconciliation

### DIFF
--- a/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/maintenance.js
+++ b/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/maintenance.js
@@ -6,6 +6,8 @@
 'require uci';
 
 var _ = function(s) { return s; };
+var TASK_POLL_INTERVAL = 2000;
+var TASK_POLL_TIMEOUT = 15 * 60 * 1000;
 
 var callGetStatus = rpc.declare({
 	object: 'luci-tailscale',
@@ -61,6 +63,11 @@ var callUpgradeScripts = rpc.declare({
 	method: 'upgrade_scripts'
 });
 
+var callReconcileCron = rpc.declare({
+	object: 'luci-tailscale',
+	method: 'reconcile_cron'
+});
+
 var callDoUninstall = rpc.declare({
 	object: 'luci-tailscale',
 	method: 'do_uninstall'
@@ -80,17 +87,34 @@ function makeInfoRow(label, value) {
 	]);
 }
 
-function pollTaskStatus(task) {
+function pollTaskStatus(task, startedAt) {
+	startedAt = startedAt || Date.now();
+
+	if (Date.now() - startedAt > TASK_POLL_TIMEOUT) {
+		return Promise.resolve({
+			done: true,
+			code: -1,
+			stdout: _('Task polling timed out after 15 minutes.')
+		});
+	}
+
 	return callGetTaskStatus(task).then(function(result) {
 		if (result && result.done)
 			return result;
 
 		return new Promise(function(resolve) {
-			window.setTimeout(resolve, 2000);
+			window.setTimeout(resolve, TASK_POLL_INTERVAL);
 		}).then(function() {
-			return pollTaskStatus(task);
+			return pollTaskStatus(task, startedAt);
 		});
 	});
+}
+
+function reconcileCronAfterSave(result) {
+	if (result && result.code === 0)
+		return true;
+
+	throw new Error((result && result.stdout) || _('Failed to reconcile cron schedule.'));
 }
 
 function handleAsyncTask(title, message, request, successMessage, errorPrefix, reloadAfterSuccess) {
@@ -313,6 +337,12 @@ return view.extend({
 
 		m = new form.Map('tailscale', _('Tailscale Maintenance'),
 			_('Manage the binary update schedule, version control, and maintenance tasks.'));
+		var mapSave = m.save.bind(m);
+		m.save = function(cb, silent) {
+			return mapSave(cb, silent).then(function() {
+				return callReconcileCron().then(reconcileCronAfterSave);
+			});
+		};
 
 		s = m.section(form.NamedSection, 'settings', 'tailscale', _('Tailscale Binary Auto-Update'));
 		s.anonymous = false;

--- a/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js
+++ b/luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js
@@ -6,6 +6,8 @@
 'require ui';
 
 var _ = function(s) { return s; };
+var TASK_POLL_INTERVAL = 2000;
+var TASK_POLL_TIMEOUT = 15 * 60 * 1000;
 
 var callGetStatus = rpc.declare({
 	object: 'luci-tailscale',
@@ -93,15 +95,25 @@ function makeInfoRow(label, value) {
 	]);
 }
 
-function pollTaskStatus(task) {
+function pollTaskStatus(task, startedAt) {
+	startedAt = startedAt || Date.now();
+
+	if (Date.now() - startedAt > TASK_POLL_TIMEOUT) {
+		return Promise.resolve({
+			done: true,
+			code: -1,
+			stdout: 'Task polling timed out after 15 minutes.'
+		});
+	}
+
 	return callGetTaskStatus(task).then(function(result) {
 		if (result && result.done)
 			return result;
 
 		return new Promise(function(resolve) {
-			window.setTimeout(resolve, 2000);
+			window.setTimeout(resolve, TASK_POLL_INTERVAL);
 		}).then(function() {
-			return pollTaskStatus(task);
+			return pollTaskStatus(task, startedAt);
 		});
 	});
 }

--- a/luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale
+++ b/luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale
@@ -3,7 +3,7 @@
 # LuCI RPC bridge for Tailscale management via rpcd exec plugin.
 
 MANAGER_BIN="${MANAGER_BIN:-/usr/bin/tailscale-manager}"
-TASK_DIR="${TASK_DIR:-/tmp/tailscale-rpc-tasks}"
+TASK_DIR="${TASK_DIR:-/var/run/tailscale-rpc-tasks}"
 LIB_DIR="${LIB_DIR:-/usr/lib/tailscale}"
 
 # shellcheck source=/dev/null
@@ -99,41 +99,107 @@ task_path() {
     printf '%s/%s' "$TASK_DIR" "$1"
 }
 
+ensure_task_dir() {
+    [ ! -L "$TASK_DIR" ] || return 1
+    mkdir -p "$TASK_DIR" || return 1
+    if [ "$(id -u 2>/dev/null)" = "0" ]; then
+        chown root:root "$TASK_DIR" 2>/dev/null || true
+    fi
+    chmod 700 "$TASK_DIR" 2>/dev/null || return 1
+}
+
+task_prefix_is_valid() {
+    case "$1" in
+        install|install-version|update|upgrade-scripts) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+task_id_is_valid() {
+    local task="$1"
+
+    case "$task" in
+        ''|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-]*)
+            return 1
+            ;;
+        install.|install-|install-version.|install-version-|update.|update-|upgrade-scripts.|upgrade-scripts-)
+            return 1
+            ;;
+        install.*|install-*|install-version.*|install-version-*|update.*|update-*|upgrade-scripts.*|upgrade-scripts-*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 new_task_id() {
     local prefix="$1"
-    local now rand
+    local old_umask tmp task
 
-    now=$(date +%s 2>/dev/null || printf '0')
-    rand=$$
-    printf '%s-%s-%s' "$prefix" "$now" "$rand"
+    task_prefix_is_valid "$prefix" || return 1
+    ensure_task_dir || return 1
+
+    old_umask=$(umask)
+    umask 077
+    tmp=$(mktemp "${TASK_DIR}/${prefix}.XXXXXX" 2>/dev/null) || {
+        umask "$old_umask"
+        return 1
+    }
+    umask "$old_umask"
+
+    task="${tmp##*/}"
+    rm -f "$tmp"
+    printf '%s' "$task"
+}
+
+print_task_error() {
+    local message="$1"
+    printf '{"done":true,"code":-1,"stdout":"%s"}' "$(json_escape "$message")"
 }
 
 start_background_task() {
     local task_prefix="$1"
     shift
 
-    local task base pid_file status_file log_file
-    task=$(new_task_id "$task_prefix")
+    local task base pid_file status_file log_file old_umask
+    task=$(new_task_id "$task_prefix") || {
+        print_code_stdout -1 "Failed to create task state"
+        return 0
+    }
     base=$(task_path "$task")
     pid_file="${base}.pid"
     status_file="${base}.status"
     log_file="${base}.log"
 
-    mkdir -p "$TASK_DIR"
-
+    old_umask=$(umask)
+    umask 077
     (
+        exec 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&-
         "$@" >"$log_file" 2>&1
         printf '%s' "$?" >"$status_file"
         rm -f "$pid_file"
-    ) &
+    ) >/dev/null 2>&1 </dev/null &
 
     printf '%s' "$!" >"$pid_file"
+    umask "$old_umask"
     printf '{"code":0,"started":true,"task":"%s","stdout":"Task started"}' "$task"
 }
 
 print_task_status() {
     local task="$1"
     local base pid_file status_file log_file pid code stdout
+    task_id_is_valid "$task" || {
+        print_task_error "Unknown task"
+        return 0
+    }
+
+    ensure_task_dir || {
+        print_task_error "Task state directory unavailable"
+        return 0
+    }
+
     base=$(task_path "$task")
     pid_file="${base}.pid"
     status_file="${base}.status"
@@ -141,6 +207,9 @@ print_task_status() {
 
     if [ -f "$status_file" ]; then
         code=$(cat "$status_file" 2>/dev/null)
+        case "$code" in
+            ''|*[!0-9]*) code=1 ;;
+        esac
         stdout=$(cat "$log_file" 2>/dev/null)
         printf '{"done":true,"code":%s,"stdout":"%s"}' "${code:-1}" "$(json_escape "$stdout")"
         rm -f "$pid_file" "$status_file" "$log_file"
@@ -156,7 +225,7 @@ print_task_status() {
         rm -f "$pid_file"
     fi
 
-    printf '{"done":false}'
+    print_task_error "Task state lost"
 }
 
 case "$1" in
@@ -179,6 +248,7 @@ list)
     "do_uninstall": {},
     "setup_firewall": {},
     "sync_scripts": {},
+    "reconcile_cron": {},
     "upgrade_scripts": {},
     "get_logs": {},
     "clear_log": { "log_type": "" }
@@ -208,10 +278,6 @@ call)
         get_task_status)
             input=$(read_input)
             task=$(json_get_param "$input" task)
-            case "$task" in
-                install-*|install-version-*|update-*|upgrade-scripts-*) ;;
-                *) printf '{"done":true,"code":-1,"stdout":"Unknown task"}' ; exit 0 ;;
-            esac
             print_task_status "$task"
             ;;
         list_versions)
@@ -285,6 +351,11 @@ call)
             ;;
         sync_scripts)
             stdout=$("$MANAGER_BIN" sync-scripts 2>&1)
+            code=$?
+            print_code_stdout "$code" "$stdout"
+            ;;
+        reconcile_cron)
+            stdout=$("$MANAGER_BIN" auto-update reconcile 2>&1)
             code=$?
             print_code_stdout "$code" "$stdout"
             ;;

--- a/luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json
+++ b/luci-app-tailscale/root/usr/share/rpcd/acl.d/luci-app-tailscale.json
@@ -33,6 +33,7 @@
 					"do_uninstall",
 					"setup_firewall",
 					"sync_scripts",
+					"reconcile_cron",
 					"upgrade_scripts",
 					"clear_log"
 				]

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -853,6 +853,9 @@ main() {
                 off|disable|0)
                     configure_auto_update "0"
                     ;;
+                reconcile)
+                    setup_cron
+                    ;;
                 status|"")
                     echo ""
                     echo "Auto-update status:"

--- a/tests/bats/deploy/cron.bats
+++ b/tests/bats/deploy/cron.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+load ../_lib/load
+
+setup() {
+    setup_test_env
+}
+
+teardown() {
+    teardown_test_env
+}
+
+@test "validate_cron_expression: accepts five-field schedules" {
+    run_in_sh auto "
+set -eu
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+validate_cron_expression '30 3 * * *'
+validate_cron_expression '*/15 1-3 * 1,6 *'
+"
+    assert_success
+}
+
+@test "validate_cron_expression: rejects command-bearing schedules" {
+    run_in_sh auto "
+set -eu
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+if validate_cron_expression '30 3 * * * /bin/sh'; then
+    echo 'command-bearing cron should fail'
+    exit 1
+fi
+"
+    assert_success
+}
+
+@test "setup_cron: rejects invalid UCI schedule before crontab write" {
+    bin_stub crontab '#!/bin/sh
+case "$1" in
+    -l) cat "${TEST_DIR}/crontab.current" 2>/dev/null; exit 0 ;;
+    -) cat > "${TEST_DIR}/crontab.written"; exit 0 ;;
+esac
+exit 1'
+
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+CONFIG_FILE='${TEST_DIR}/tailscale.config'
+CRON_SCRIPT='${TEST_DIR}/tailscale-update'
+printf 'config tailscale settings\n' > \"\$CONFIG_FILE\"
+printf 'existing\n' > '${TEST_DIR}/crontab.current'
+
+config_load() { :; }
+config_get() {
+    case \"\$3\" in
+        auto_update) eval \"\$1=1\" ;;
+        update_cron) eval \"\$1='30 3 * * * /bin/sh'\" ;;
+        *) eval \"\$1=\${4:-}\" ;;
+    esac
+}
+
+if setup_cron >/dev/null 2>&1; then
+    echo 'setup_cron should fail'
+    exit 1
+fi
+
+[ ! -e '${TEST_DIR}/crontab.written' ] || {
+    echo 'crontab was written'
+    exit 1
+}
+"
+    assert_success
+}
+
+@test "setup_cron: writes validated managed cron" {
+    bin_stub crontab '#!/bin/sh
+case "$1" in
+    -l) cat "${TEST_DIR}/crontab.current" 2>/dev/null; exit 0 ;;
+    -) cat > "${TEST_DIR}/crontab.written"; exit 0 ;;
+esac
+exit 1'
+
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+CONFIG_FILE='${TEST_DIR}/tailscale.config'
+CRON_SCRIPT='${TEST_DIR}/tailscale-update'
+printf 'config tailscale settings\n' > \"\$CONFIG_FILE\"
+printf '0 1 * * * /bin/echo keep\n' > '${TEST_DIR}/crontab.current'
+
+config_load() { :; }
+config_get() {
+    case \"\$3\" in
+        auto_update) eval \"\$1=1\" ;;
+        update_cron) eval \"\$1='30 3 * * *'\" ;;
+        *) eval \"\$1=\${4:-}\" ;;
+    esac
+}
+
+setup_cron
+grep -Fq '0 1 * * * /bin/echo keep' '${TEST_DIR}/crontab.written'
+grep -Fq \"30 3 * * * ${TEST_DIR}/tailscale-update # openwrt-tailscale:binary-update\" '${TEST_DIR}/crontab.written'
+"
+    assert_success
+}

--- a/tests/bats/rpcd/dispatch.bats
+++ b/tests/bats/rpcd/dispatch.bats
@@ -36,6 +36,8 @@ grep -Fq 'json-status' '${TEST_DIR}/manager-call' || { echo 'manager not called 
 }
 
 @test "rpcd bridge passes install params to manager" {
+    local TASK_DIR="${TEST_DIR}/tasks"
+
     cat > "${MANAGER}" <<MSCRIPT
 #!/bin/sh
 printf '%s\n' "\$*" > '${TEST_DIR}/manager-call'
@@ -44,7 +46,7 @@ MSCRIPT
     chmod +x "${MANAGER}"
 
     run bash -c "
-output=\$(printf '{\"source\":\"small\",\"storage\":\"ram\",\"auto_update\":\"1\"}' | MANAGER_BIN='${MANAGER}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_install)
+output=\$(printf '{\"source\":\"small\",\"storage\":\"ram\",\"auto_update\":\"1\"}' | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_install)
 printf '%s' \"\$output\" | grep -Fq '\"started\":true' || { echo 'missing started: '\$output; exit 1; }
 sleep 1
 grep -Fq 'install-quiet --source small --storage ram --auto-update 1' '${TEST_DIR}/manager-call' || {
@@ -57,6 +59,8 @@ grep -Fq 'install-quiet --source small --storage ram --auto-update 1' '${TEST_DI
 }
 
 @test "rpcd bridge reports async task status after completion" {
+    local TASK_DIR="${TEST_DIR}/tasks"
+
     cat > "${MANAGER}" <<MSCRIPT
 #!/bin/sh
 printf 'hello from task\n'
@@ -64,12 +68,12 @@ MSCRIPT
     chmod +x "${MANAGER}"
 
     run bash -c "
-start=\$(printf '{\"source\":\"small\"}' | MANAGER_BIN='${MANAGER}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_install)
+start=\$(printf '{\"source\":\"small\"}' | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_install)
 printf '%s' \"\$start\" | grep -Fq '\"started\":true' || { echo 'missing started'; exit 1; }
 task=\$(printf '%s' \"\$start\" | sed -n 's/.*\"task\":\"\([^\"]*\)\".*/\1/p')
 [ -n \"\$task\" ] || { echo 'missing task id'; exit 1; }
 sleep 1
-status=\$(printf '{\"task\":\"%s\"}' \"\$task\" | MANAGER_BIN='${MANAGER}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call get_task_status)
+status=\$(printf '{\"task\":\"%s\"}' \"\$task\" | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call get_task_status)
 printf '%s' \"\$status\" | grep -Fq '\"done\":true' || { echo 'missing done: '\$status; exit 1; }
 printf '%s' \"\$status\" | grep -Fq '\"code\":0' || { echo 'missing code: '\$status; exit 1; }
 printf '%s' \"\$status\" | grep -Fq 'hello from task' || { echo 'missing output: '\$status; exit 1; }
@@ -79,6 +83,7 @@ printf '%s' \"\$status\" | grep -Fq 'hello from task' || { echo 'missing output:
 
 @test "rpcd bridge keeps multiline output as valid JSON" {
     command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    local TASK_DIR="${TEST_DIR}/tasks"
 
     cat > "${MANAGER}" <<MSCRIPT
 #!/bin/sh
@@ -87,11 +92,62 @@ MSCRIPT
     chmod +x "${MANAGER}"
 
     run bash -c "
-start=\$(printf '{\"source\":\"small\"}' | MANAGER_BIN='${MANAGER}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_install)
+start=\$(printf '{\"source\":\"small\"}' | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_install)
 task=\$(printf '%s' \"\$start\" | sed -n 's/.*\"task\":\"\([^\"]*\)\".*/\1/p')
 sleep 1
-status=\$(printf '{\"task\":\"%s\"}' \"\$task\" | MANAGER_BIN='${MANAGER}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call get_task_status)
+status=\$(printf '{\"task\":\"%s\"}' \"\$task\" | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call get_task_status)
 printf '%s' \"\$status\" | python3 -m json.tool >/dev/null || { echo 'invalid JSON'; exit 1; }
+"
+    assert_success
+}
+
+@test "rpcd bridge creates private random task state" {
+    local TASK_DIR="${TEST_DIR}/tasks"
+
+    cat > "${MANAGER}" <<MSCRIPT
+#!/bin/sh
+sleep 30
+printf 'done\n'
+MSCRIPT
+    chmod +x "${MANAGER}"
+
+    run bash -c "printf '{}' | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_update"
+    assert_success
+
+    task=$(printf '%s' "$output" | sed -n 's/.*"task":"\([^"]*\)".*/\1/p')
+    [ -n "$task" ] || { echo 'missing task id'; exit 1; }
+    [[ "$task" == update.* ]] || { echo "unexpected task id: $task"; exit 1; }
+    [[ "$task" =~ ^update-[0-9]+-[0-9]+$ ]] && {
+        echo "predictable task id: $task"
+        exit 1
+    }
+
+    assert_file_permission 700 "${TASK_DIR}"
+    assert_file_permission 600 "${TASK_DIR}/${task}.pid"
+
+    pid=$(cat "${TASK_DIR}/${task}.pid")
+    kill "$pid" 2>/dev/null || true
+    rm -f "${TASK_DIR}/${task}.pid" "${TASK_DIR}/${task}.log" "${TASK_DIR}/${task}.status"
+}
+
+@test "rpcd bridge rejects task traversal input" {
+    run bash -c "
+status=\$(printf '{\"task\":\"install-../../etc/passwd\"}' | MANAGER_BIN='${MANAGER}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call get_task_status)
+printf '%s' \"\$status\" | grep -Fq '\"done\":true' || { echo 'missing done: '\$status; exit 1; }
+printf '%s' \"\$status\" | grep -Fq '\"code\":-1' || { echo 'missing code: '\$status; exit 1; }
+printf '%s' \"\$status\" | grep -Fq 'Unknown task' || { echo 'missing error: '\$status; exit 1; }
+"
+    assert_success
+}
+
+@test "rpcd bridge reports lost task state as terminal error" {
+    local TASK_DIR="${TEST_DIR}/tasks"
+
+    run bash -c "
+status=\$(printf '{\"task\":\"install.ABC123\"}' | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call get_task_status)
+printf '%s' \"\$status\" | grep -Fq '\"done\":true' || { echo 'missing done: '\$status; exit 1; }
+printf '%s' \"\$status\" | grep -Fq '\"code\":-1' || { echo 'missing code: '\$status; exit 1; }
+printf '%s' \"\$status\" | grep -Fq 'Task state lost' || { echo 'missing error: '\$status; exit 1; }
 "
     assert_success
 }

--- a/usr/lib/tailscale/deploy.sh
+++ b/usr/lib/tailscale/deploy.sh
@@ -409,20 +409,68 @@ sync_managed_scripts() {
 
 # Reconcile cron jobs from UCI configuration
 # Removes all managed entries and re-adds only enabled ones
+validate_cron_expression() {
+    local expr="$1"
+    local field
+    local field_count restore_glob=1
+
+    [ -n "$expr" ] || return 1
+    if printf '%s' "$expr" | grep '[[:cntrl:]]' >/dev/null 2>&1; then
+        return 1
+    fi
+
+    case "$-" in
+        *f*) restore_glob=0 ;;
+    esac
+    set -f
+    # shellcheck disable=SC2086
+    set -- $expr
+    field_count="$#"
+    [ "$restore_glob" = "0" ] || set +f
+
+    [ "$field_count" -eq 5 ] || return 1
+
+    for field in "$@"; do
+        case "$field" in
+            ''|*[!0123456789*/,-]*)
+                return 1
+                ;;
+        esac
+    done
+
+    return 0
+}
+
 setup_cron() {
     local auto_update="" update_cron=""
 
-    if [ -f "$CONFIG_FILE" ] && [ -r /lib/functions.sh ]; then
-        . /lib/functions.sh
+    if [ -f "$CONFIG_FILE" ]; then
+        if ! type config_load >/dev/null 2>&1; then
+            [ -r /lib/functions.sh ] && . /lib/functions.sh
+        fi
+    fi
+
+    if type config_load >/dev/null 2>&1 && type config_get >/dev/null 2>&1; then
         config_load tailscale
         config_get auto_update settings auto_update "0"
         config_get update_cron settings update_cron "30 3 * * *"
     fi
 
+    if [ "$auto_update" = "1" ]; then
+        if ! validate_cron_expression "$update_cron"; then
+            log_error "Invalid update_cron expression: ${update_cron}"
+            return 1
+        fi
+    fi
+
     # Remove all managed entries first, including legacy script auto-update
     # entries from older installs (the feature is no longer supported).
     local existing
-    existing=$(crontab -l 2>/dev/null | grep -v "$CRON_TAG_BINARY" | grep -v "$CRON_TAG_SCRIPT" | grep -v "$CRON_SCRIPT" | grep -v "$LEGACY_SCRIPT_UPDATE_CRON_SCRIPT") || true
+    existing=$(crontab -l 2>/dev/null \
+        | grep -Fv "$CRON_TAG_BINARY" \
+        | grep -Fv "$CRON_TAG_SCRIPT" \
+        | grep -Fv "$CRON_SCRIPT" \
+        | grep -Fv "$LEGACY_SCRIPT_UPDATE_CRON_SCRIPT") || true
 
     local new_cron="$existing"
 
@@ -432,7 +480,10 @@ ${update_cron} ${CRON_SCRIPT} ${CRON_TAG_BINARY}"
     fi
 
     # Remove trailing/leading blank lines and apply
-    printf '%s\n' "$new_cron" | grep -v '^$' | crontab - 2>/dev/null || true
+    if ! printf '%s\n' "$new_cron" | grep -v '^$' | crontab - 2>/dev/null; then
+        log_error "Failed to update crontab"
+        return 1
+    fi
 
     # Purge the defunct script auto-update helper left over from older installs.
     rm -f "$LEGACY_SCRIPT_UPDATE_CRON_SCRIPT" 2>/dev/null || true
@@ -444,7 +495,14 @@ ${update_cron} ${CRON_SCRIPT} ${CRON_TAG_BINARY}"
 # Remove all managed cron jobs
 remove_cron() {
     local existing
-    existing=$(crontab -l 2>/dev/null | grep -v "$CRON_TAG_BINARY" | grep -v "$CRON_TAG_SCRIPT" | grep -v "$CRON_SCRIPT" | grep -v "$LEGACY_SCRIPT_UPDATE_CRON_SCRIPT") || true
-    printf '%s\n' "$existing" | grep -v '^$' | crontab - 2>/dev/null || true
+    existing=$(crontab -l 2>/dev/null \
+        | grep -Fv "$CRON_TAG_BINARY" \
+        | grep -Fv "$CRON_TAG_SCRIPT" \
+        | grep -Fv "$CRON_SCRIPT" \
+        | grep -Fv "$LEGACY_SCRIPT_UPDATE_CRON_SCRIPT") || true
+    if ! printf '%s\n' "$existing" | grep -v '^$' | crontab - 2>/dev/null; then
+        log_error "Failed to update crontab"
+        return 1
+    fi
     log_info "Removed managed cron jobs"
 }

--- a/usr/lib/tailscale/deploy.sh
+++ b/usr/lib/tailscale/deploy.sh
@@ -488,7 +488,9 @@ ${update_cron} ${CRON_SCRIPT} ${CRON_TAG_BINARY}"
     # Purge the defunct script auto-update helper left over from older installs.
     rm -f "$LEGACY_SCRIPT_UPDATE_CRON_SCRIPT" 2>/dev/null || true
 
-    [ -x /etc/init.d/cron ] && /etc/init.d/cron restart >/dev/null 2>&1
+    if [ -x /etc/init.d/cron ]; then
+        /etc/init.d/cron restart >/dev/null 2>&1 || true
+    fi
     log_info "Cron jobs reconciled from UCI configuration"
 }
 


### PR DESCRIPTION
TL;DR

LuCI async task state used predictable names and loose task validation, and UCI cron values could be written into crontab without server-side validation. This hardens task state, returns terminal errors for lost tasks, validates cron schedules before writes, and reconciles cron after LuCI maintenance saves.

Files to review

| File | Why |
| --- | --- |
| `luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale` | Owns async task IDs, task state files, task polling responses, and the new cron reconcile RPC. |
| `usr/lib/tailscale/deploy.sh` | Owns managed cron reconciliation and server-side cron expression validation. |
| `luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/maintenance.js` | Adds task polling timeout behavior and cron reconciliation after settings saves. |
| `luci-app-tailscale/htdocs/luci-static/resources/view/tailscale/status.js` | Adds install task polling timeout behavior. |
| `tests/bats/deploy/cron.bats` and `tests/bats/rpcd/dispatch.bats` | Cover cron validation and hardened RPC task behavior. |

Why

The reported checklist maps to concrete LuCI surfaces:

- Predictable RPC task IDs and broad prefix validation allowed crafted task names to reach filesystem-backed state paths.
- Default task state permissions depended on the runtime umask and a shared temporary directory.
- Missing task files returned an in-progress response, leaving the frontend polling indefinitely.
- LuCI cron values were validated in the browser and then written by shell reconciliation without an equivalent server-side guard.
- Saving LuCI auto-update settings updated UCI and left managed cron state stale until another reconciliation path ran.

How

- Move RPC task state to a private runtime directory, force 0700 directory permissions, create IDs through `mktemp`, and use 0600 task files.
- Strictly validate task IDs before resolving state paths and return terminal JSON errors for unknown or lost state.
- Close inherited background-task file descriptors so long tasks return control to RPC callers.
- Add `validate_cron_expression` before any managed crontab write and surface crontab write failures.
- Add `reconcile_cron` RPC plus ACL access, and call it after LuCI maintenance form saves.
- Add 15-minute frontend polling timeouts for install/update task flows.

Tests

- `make lint`
- `make test`
- `tests/bats/_deps/bats-core/bin/bats tests/bats/rpcd/dispatch.bats tests/bats/deploy/cron.bats`
