### PR TITLE
fix: version, sync warning, manual-install detection error

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
           required: true
         - label: I have read the relevant section of the [documentation](https://fl0w1nd.github.io/openwrt-tailscale/).
           required: true
-        - label: I am running the latest `tailscale-manager` (`tailscale-manager update-script`).
+        - label: I am running the latest `tailscale-manager` (`tailscale-manager self-update`).
           required: false
 
   - type: input

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -764,9 +764,10 @@ main() {
     mkdir -p "$(dirname "$LOG_FILE")"
     local reexeced="${TAILSCALE_MANAGER_REEXEC:-0}"
 
-    # Bootstrap: ensure module libraries are available for commands that need them
+    # Bootstrap: ensure module libraries are available for commands that need them.
+    # Informational commands (help/version) stay offline and need no libraries.
     case "${1:-}" in
-        -h|--help|help) ;;
+        -h|--help|help|-v|--version) ;;
         *)
             _ensure_libraries || {
                 log_error "Failed to initialize runtime libraries from ${REPO_BASE_URL}/usr/lib/tailscale"
@@ -782,7 +783,7 @@ main() {
     if [ "$reexeced" != "1" ] \
         && type check_script_update >/dev/null 2>&1; then
         case "${1:-}" in
-            self-update|sync-scripts|install-quiet|install-version|list-versions|list-official-versions|json-*) ;;
+            -h|--help|help|-v|--version|self-update|sync-scripts|install-quiet|install-version|list-versions|list-official-versions|json-*) ;;
             *) check_script_update "$@" || true ;;
         esac
     fi
@@ -918,6 +919,9 @@ main() {
         json-script-info)
             cmd_json_script_info
             ;;
+        -v|--version)
+            echo "${VERSION}"
+            ;;
         -h|--help|help)
             echo "OpenWRT Tailscale Manager v${VERSION}"
             echo ""
@@ -940,6 +944,7 @@ main() {
             echo "  auto-update      Configure auto-update (on/off/status)"
             echo "  net-mode         Configure networking mode (auto/tun/userspace/status)"
             echo "  help             Show this help"
+            echo "  --version        Print the manager version and exit"
             echo ""
             echo "Environment variables:"
             echo "  TAILSCALE_SOURCE=official|small"

--- a/tests/bats/cli/version.bats
+++ b/tests/bats/cli/version.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# tests/bats/cli/version.bats
+# Covers the `--version` entry point: it must print the manager version and
+# stay fully offline (no script-update check / managed-file sync).
+
+load ../_lib/load
+
+setup() {
+    setup_test_env
+}
+
+teardown() {
+    teardown_test_env
+}
+
+@test "main --version prints the version without touching the network" {
+    # Fail loudly and leave a marker if wget is ever invoked.
+    bin_stub wget "#!/bin/sh
+touch '${TEST_DIR}/wget-called'
+exit 1"
+
+    run env PATH="${STUB_BIN}:${PATH}" \
+        LIB_DIR="${REPO_ROOT}/usr/lib/tailscale" \
+        LOG_FILE="${TEST_DIR}/tailscale-manager.log" \
+        sh "${REPO_ROOT}/tailscale-manager.sh" --version </dev/null
+
+    assert_success
+
+    expected=$(sed -n 's/^VERSION="\([^"]*\)"/\1/p' "${REPO_ROOT}/tailscale-manager.sh" | head -1)
+    [ -n "${expected}" ] || { echo "could not read VERSION from manager script"; false; }
+    [ "${output}" = "${expected}" ] || { echo "expected '${expected}', got '${output}'"; false; }
+
+    [ ! -f "${TEST_DIR}/wget-called" ] || { echo "--version must not access the network"; false; }
+    case "${output}" in
+        *"Checking for script updates"*) echo "--version must not run the update check"; false ;;
+    esac
+}
+
+@test "main -v is an alias for --version" {
+    run env PATH="${STUB_BIN}:${PATH}" \
+        LIB_DIR="${REPO_ROOT}/usr/lib/tailscale" \
+        LOG_FILE="${TEST_DIR}/tailscale-manager.log" \
+        sh "${REPO_ROOT}/tailscale-manager.sh" -v </dev/null
+
+    assert_success
+
+    expected=$(sed -n 's/^VERSION="\([^"]*\)"/\1/p' "${REPO_ROOT}/tailscale-manager.sh" | head -1)
+    [ "${output}" = "${expected}" ] || { echo "expected '${expected}', got '${output}'"; false; }
+}

--- a/tests/bats/json/status.bats
+++ b/tests/bats/json/status.bats
@@ -97,6 +97,43 @@ esac
     assert_success
 }
 
+@test "cmd_json_install_info: detects manual install without version sentinel" {
+    mkdir -p "${TEST_DIR}/opt/tailscale"
+    # A manually installed binary: executable present, but no manager-written
+    # "version"/"source" sentinel files.
+    cat > "${TEST_DIR}/opt/tailscale/tailscale" <<'EOF'
+#!/bin/sh
+[ "$1" = version ] && echo "1.98.3"
+EOF
+    chmod +x "${TEST_DIR}/opt/tailscale/tailscale"
+
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+PERSISTENT_DIR='${TEST_DIR}/opt/tailscale'
+RAM_DIR='${TEST_DIR}/ram/tailscale'
+
+bin_dir=\$(_find_bin_dir)
+[ \"\$bin_dir\" = '${TEST_DIR}/opt/tailscale' ] || { echo \"expected ${TEST_DIR}/opt/tailscale, got \$bin_dir\"; exit 1; }
+
+output=\$(cmd_json_install_info)
+case \"\$output\" in
+    *'\"installed\":true'*'\"version\":\"1.98.3\"'*)
+        ;;
+    *)
+        echo \"unexpected output: \$output\"
+        exit 1
+        ;;
+esac
+"
+    assert_success
+}
+
 @test "_find_bin_dir: uses configured persistent dir" {
     mkdir -p "${TEST_DIR}/custom/tailscale"
     printf '1.76.1\n' > "${TEST_DIR}/custom/tailscale/version"

--- a/usr/lib/tailscale/json.sh
+++ b/usr/lib/tailscale/json.sh
@@ -25,10 +25,25 @@
 # Internal Helpers
 # ============================================================================
 
+# Return 0 if the directory holds an executable Tailscale binary, even when the
+# manager's "version" sentinel is absent (e.g. a manually installed binary).
+_dir_has_tailscale_binary() {
+    local d="$1"
+    [ -n "$d" ] || return 1
+
+    local f
+    for f in tailscale tailscaled tailscale.combined; do
+        [ -x "$d/$f" ] && return 0
+    done
+    return 1
+}
+
 _find_bin_dir() {
     local d
     local uci_dir
     uci_dir=$(uci -q get tailscale.settings.bin_dir 2>/dev/null) || uci_dir=""
+
+    # Prefer directories carrying the manager's "version" sentinel file.
     if [ -n "$uci_dir" ] && [ -f "$uci_dir/version" ]; then
         echo "$uci_dir"
         return 0
@@ -36,7 +51,39 @@ _find_bin_dir() {
     for d in "$PERSISTENT_DIR" "$RAM_DIR"; do
         [ -f "$d/version" ] && { echo "$d"; return 0; }
     done
+
+    # Fall back to a Tailscale binary installed outside the manager (no
+    # sentinel). This lets the LuCI UI recognise manual installs, e.g. a
+    # binary placed under /opt/tailscale on external storage.
+    for d in "$uci_dir" "$PERSISTENT_DIR" "$RAM_DIR"; do
+        [ -n "$d" ] || continue
+        _dir_has_tailscale_binary "$d" && { echo "$d"; return 0; }
+    done
+
     return 1
+}
+
+# Resolve the installed Tailscale version for a bin_dir. Prefer the manager's
+# "version" sentinel; otherwise query the binary directly so manually installed
+# Tailscale (without the sentinel) still reports a version.
+_get_installed_version() {
+    local bin_dir="$1"
+    [ -n "$bin_dir" ] || return 1
+
+    if [ -f "$bin_dir/version" ]; then
+        cat "$bin_dir/version" 2>/dev/null
+        return 0
+    fi
+
+    local bin=""
+    if [ -x "$bin_dir/tailscale" ]; then
+        bin="$bin_dir/tailscale"
+    elif command -v tailscale >/dev/null 2>&1; then
+        bin="tailscale"
+    fi
+    [ -n "$bin" ] || return 1
+
+    "$bin" version 2>/dev/null | head -n1
 }
 
 _get_installed_source() {
@@ -183,7 +230,7 @@ cmd_json_status() {
     fi
 
     local version="" source_type=""
-    version=$(cat "$bin_dir/version" 2>/dev/null) || true
+    version=$(_get_installed_version "$bin_dir") || true
     source_type=$(_get_installed_source "$bin_dir") || true
 
     local pid_str="" pid="" running="false"
@@ -402,7 +449,7 @@ cmd_json_install_info() {
     fi
 
     local version="" source=""
-    version=$(cat "$bin_dir/version" 2>/dev/null) || true
+    version=$(_get_installed_version "$bin_dir") || true
     source=$(_get_installed_source "$bin_dir") || true
 
     printf '{'

--- a/usr/lib/tailscale/selfupdate.sh
+++ b/usr/lib/tailscale/selfupdate.sh
@@ -202,7 +202,8 @@ check_script_update() {
     case "$?" in
         10) return 10 ;;
         *)
-            echo "[WARN] Failed to sync managed files for v${VERSION}"
+            echo "[WARN] Could not sync managed files for v${VERSION} (LuCI app and helper libraries may be outdated)."
+            echo "[WARN] Retry with 'tailscale-manager sync-scripts'. If it keeps failing, check free disk space and network access to GitHub."
             return 20
             ;;
     esac


### PR DESCRIPTION
## Summary

Fixes the three problems reported in #26 (TP-Link Archer C7, `mips_24kc`, Tailscale manually installed under `/opt/tailscale`).

- **`--version` did not exist.** The bug-report template tells users to run `tailscale-manager --version` / `update-script`, but neither command existed. Added a `--version`/`-v` command, and pointed the issue template at the real `self-update` command.
- **`[WARN] Failed to sync managed files` on every command.** Informational commands (`help`, `--version`) now skip the library bootstrap and the script-update check entirely, so they stay offline. When a sync genuinely fails, the warning is now actionable (what is affected + how to recover).
- **LuCI showed "not installed" for a manually installed Tailscale.** `_find_bin_dir` only recognised installs carrying the manager's `version` sentinel file. It now falls back to detecting a `tailscale`/`tailscaled`/`tailscale.combined` executable in the candidate directories (UCI `bin_dir`, `/opt/tailscale`, RAM dir) and resolves the version from the binary when the sentinel is absent.

## Changes

- `tailscale-manager.sh`: add `-v|--version`; exclude help/version from `_ensure_libraries` and `check_script_update`; document `--version` in help.
- `usr/lib/tailscale/selfupdate.sh`: actionable managed-file sync warning.
- `usr/lib/tailscale/json.sh`: `_dir_has_tailscale_binary` + `_get_installed_version` helpers; `_find_bin_dir` fallback; status/install-info use the version helper.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: `update-script` → `self-update`.
- Tests: `tests/bats/cli/version.bats` (offline `--version`), and a manual-install detection case in `tests/bats/json/status.bats`.

## Test plan

- [x] `make syntax check-sync check-static` pass
- [x] `make shellcheck` passes (shellcheck installed)
- [x] `sh tests/run-bats.sh` — all 183 tests green (incl. new cases)
- [x] Manual: `--version`, `-v`, and `help` print expected output with no network access

Refs #26