### PR TITLE
refactor(cli): standardize command names, separate Tailscale and manager updates

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.4.0 (2026-06-07)
+
+- Clearer separation between updating the **Tailscale binary** (`update`, `auto-update`) and updating **the manager itself** (`self-update`); `help` is now grouped by target so the two can no longer be confused
+- Standardised command names (breaking): `install-quiet` → `install --yes`, `setup-firewall` → `setup-subnet-routing`, `list-versions` → `list-small-versions`
+- Non-interactive flags are now uniformly `--yes` (`update --yes`, `self-update --yes`), and `auto-update` prefers `enable`/`disable`/`status` (the old `on`/`off`/`1`/`0` still work)
+- UCI settings are unchanged; only the CLI verbs above were renamed
+
 ## v4.3.0 (2026-06-07)
 
 - Greatly simplified self-update: `self-update` now reinstalls the whole management layer (scripts, libraries, LuCI app) in one step while preserving your UCI config, node state, and installed binary; re-running is always safe and also repairs corrupted files

--- a/docs/en/guide/auto-update.md
+++ b/docs/en/guide/auto-update.md
@@ -2,17 +2,19 @@
 
 The manager auto-updates the Tailscale binary on a schedule. The management script and LuCI interface are **manual-only** and never upgrade themselves.
 
-## Binary Auto-Update
+## Tailscale Binary Auto-Update
 
-When enabled, a daily cron job checks for and installs new Tailscale releases.
+When enabled, a daily cron job checks for and installs new Tailscale releases. This only affects the **Tailscale binary**, never the manager itself.
 
 ### Enable / Disable
 
 ```sh
-tailscale-manager auto-update on      # Enable
-tailscale-manager auto-update off     # Disable
-tailscale-manager auto-update status  # Check status
+tailscale-manager auto-update enable   # Enable
+tailscale-manager auto-update disable  # Disable
+tailscale-manager auto-update status   # Check status
 ```
+
+(The older `on` / `off` / `1` / `0` values are still accepted.)
 
 ### How It Works
 

--- a/docs/en/guide/commands.md
+++ b/docs/en/guide/commands.md
@@ -12,38 +12,46 @@ Running without arguments opens the interactive menu.
 
 ## Commands
 
-### Core
+::: tip Two independent kinds of "update"
+- `update` / `auto-update` act on the **Tailscale binary** (the VPN program this tool installs).
+- `self-update` acts on **this manager** (its scripts and the LuCI app).
+
+They are completely independent: updating Tailscale never touches the manager, and `self-update` never touches Tailscale.
+:::
+
+### Core (Tailscale binary)
 
 | Command | Description |
 |---------|-------------|
 | `install` | Interactive Tailscale installation |
-| `update` | Update Tailscale to the latest version |
-| `uninstall` | Remove Tailscale and all related files |
+| `update [--yes]` | Update the **Tailscale binary** to the latest version (`--yes` skips the prompt) |
+| `rollback` | Roll back the **Tailscale binary** to the previous version |
+| `uninstall [--yes]` | Remove Tailscale and all related files (`--yes` skips the prompt) |
 | `status` | Show current installation and service status |
 
 ### Installation Variants
 
 | Command | Description |
 |---------|-------------|
-| `install-quiet` | Non-interactive installation (for scripting) |
+| `install --yes` | Non-interactive installation (for LuCI/automation) |
 | `install-version <ver>` | Install a specific Tailscale version |
 | `download-only` | Download binary without installing |
 
 #### Install Options
 
-Both `install-quiet` and `install-version` accept these flags:
+`install --yes` and `install-version` accept these flags:
 
 | Flag | Values | Description |
 |------|--------|-------------|
 | `--source` | `official` / `small` | Download source |
-| `--storage` | `persistent` / `ram` | Storage mode (`install-quiet` only) |
-| `--auto-update` | `0` / `1` | Enable daily auto-update cron (`install-quiet` only) |
+| `--storage` | `persistent` / `ram` | Storage mode (`install --yes` only) |
+| `--auto-update` | `0` / `1` | Enable daily Tailscale auto-update cron (`install --yes` only) |
 | `--bin-dir` | absolute path | Custom binary directory for persistent mode (see [Storage Modes](/en/guide/storage-modes#custom-binary-directory)) |
 
 Examples:
 
 ```sh
-tailscale-manager install-quiet --source small --bin-dir /mnt/sda1/tailscale
+tailscale-manager install --yes --source small --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 
@@ -51,28 +59,36 @@ tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 
 | Command | Description |
 |---------|-------------|
-| `list-versions [n]` | List available Small binary versions (default: 10) |
+| `list-small-versions [n]` | List available Small binary versions (default: 10) |
 | `list-official-versions [n]` | List available Official versions (default: 20) |
 
 ### Network Configuration
 
 | Command | Description |
 |---------|-------------|
-| `setup-firewall` | Configure tailscale0 interface and firewall zone |
+| `setup-subnet-routing` | Configure tailscale0 interface and firewall zone |
 | `net-mode [auto\|tun\|userspace\|status]` | Get or set networking mode |
 
-### Script Management
+### Tailscale auto-update
 
 | Command | Description |
 |---------|-------------|
-| `self-update` | Reinstall the management layer (manager script, libraries, and LuCI app) to the latest version in one step |
-| `auto-update [on\|off\|status]` | Manage binary auto-update cron job |
+| `auto-update [enable\|disable\|status]` | Manage the daily **Tailscale binary** auto-update cron job |
+
+(`on`/`off`/`1`/`0` are still accepted as aliases for `enable`/`disable`.)
+
+### Manager self-update
+
+| Command | Description |
+|---------|-------------|
+| `self-update [--yes]` | Reinstall **this manager** (script, libraries, and LuCI app) to the latest version in one step. Does **not** touch the Tailscale binary. |
 
 ### Other
 
 | Command | Description |
 |---------|-------------|
 | `help` | Show help message |
+| `--version`, `-v` | Print the manager version and exit |
 
 ## Service Commands
 

--- a/docs/en/guide/storage-modes.md
+++ b/docs/en/guide/storage-modes.md
@@ -31,17 +31,17 @@ Binary directory [/opt/tailscale]:
 
 Enter any absolute path (e.g. `/mnt/sda1/tailscale`) or press Enter for the default.
 
-**Non-interactive install** — pass `--bin-dir` (note: the interactive `install` command ignores flags, use `install-quiet` for scripting):
+**Non-interactive install** — pass `--bin-dir` (note: the interactive `install` command ignores flags, use `install --yes` for scripting):
 
 ```sh
-tailscale-manager install-quiet --bin-dir /mnt/sda1/tailscale
+tailscale-manager install --yes --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 
 **Change the directory later** — run an install command again with the new path. Your Tailscale state is kept separately, so this only replaces the binaries and updates the configured binary directory:
 
 ```sh
-tailscale-manager install-quiet --bin-dir /mnt/sdb1/tailscale
+tailscale-manager install --yes --bin-dir /mnt/sdb1/tailscale
 ```
 
 To keep the currently installed Tailscale version, install that version explicitly:

--- a/docs/en/guide/subnet-routing.md
+++ b/docs/en/guide/subnet-routing.md
@@ -7,7 +7,7 @@ Subnet routing lets you access your local network from other Tailscale devices.
 During installation, you'll be prompted to configure subnet routing. You can also run it later:
 
 ```sh
-tailscale-manager setup-firewall
+tailscale-manager setup-subnet-routing
 ```
 
 This will:
@@ -55,4 +55,4 @@ Then approve the exit node in the Admin Console.
 
 ## Userspace Mode
 
-In [userspace mode](/en/guide/userspace-mode), the `tailscale0` interface is not created. Instead, Tailscale provides SOCKS5 and HTTP proxy listeners. The `setup-firewall` command is not needed.
+In [userspace mode](/en/guide/userspace-mode), the `tailscale0` interface is not created. Instead, Tailscale provides SOCKS5 and HTTP proxy listeners. The `setup-subnet-routing` command is not needed.

--- a/docs/en/guide/troubleshooting.md
+++ b/docs/en/guide/troubleshooting.md
@@ -66,7 +66,7 @@ tailscale-manager install
 **Solution**: Set up subnet routing:
 
 ```sh
-tailscale-manager setup-firewall
+tailscale-manager setup-subnet-routing
 tailscale set --advertise-routes=192.168.1.0/24
 ```
 

--- a/docs/en/guide/uninstall.md
+++ b/docs/en/guide/uninstall.md
@@ -14,7 +14,7 @@ This removes:
 - UCI configuration (`/etc/config/tailscale`)
 - Module libraries (`/usr/lib/tailscale/`)
 - LuCI interface files (if installed)
-- Network interface and firewall zone (if configured via `setup-firewall`)
+- Network interface and firewall zone (if configured via `setup-subnet-routing`)
 
 ## Preserved Files
 

--- a/docs/en/guide/userspace-mode.md
+++ b/docs/en/guide/userspace-mode.md
@@ -62,7 +62,7 @@ tailscale set --advertise-routes=192.168.1.0/24
 ```
 
 ::: warning Limitations
-- The `tailscale0` interface is **not** created — `setup-firewall` is not needed.
+- The `tailscale0` interface is **not** created — `setup-subnet-routing` is not needed.
 - Supports TCP, UDP, and ICMP (ping), but not all IP protocols.
 - Performance is typically lower than kernel TUN mode.
 :::

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,6 +2,13 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.4.0 (2026-06-07)
+
+- 明确区分「更新 **Tailscale 二进制**」（`update`、`auto-update`）与「更新 **管理器本身**」（`self-update`）；`help` 现按作用对象分组，两者不再混淆
+- 规范命令命名（破坏性变更）：`install-quiet` → `install --yes`、`setup-firewall` → `setup-subnet-routing`、`list-versions` → `list-small-versions`
+- 非交互参数统一为 `--yes`（`update --yes`、`self-update --yes`）；`auto-update` 推荐使用 `enable`/`disable`/`status`（仍兼容旧的 `on`/`off`/`1`/`0`）
+- UCI 配置保持不变，仅重命名了上述 CLI 命令
+
 ## v4.3.0 (2026-06-07)
 
 - 大幅简化自更新：`self-update` 现在一步重装整个管理层（脚本、库、LuCI 界面），并保留 UCI 配置、节点状态和已装二进制；重复执行总是安全，也能修复损坏文件

--- a/docs/zh/guide/auto-update.md
+++ b/docs/zh/guide/auto-update.md
@@ -2,17 +2,19 @@
 
 管理器仅对 Tailscale 二进制文件提供定时自动更新；管理脚本和 LuCI 界面**只能手动更新**，不会自动升级。
 
-## 二进制自动更新
+## Tailscale 二进制自动更新
 
-启用后，每日定时任务会检查并安装新版本。
+启用后，每日定时任务会检查并安装新版本。该机制只作用于 **Tailscale 二进制**，不会影响管理器本身。
 
 ### 启用 / 禁用
 
 ```sh
-tailscale-manager auto-update on      # 启用
-tailscale-manager auto-update off     # 禁用
-tailscale-manager auto-update status  # 查看状态
+tailscale-manager auto-update enable   # 启用
+tailscale-manager auto-update disable  # 禁用
+tailscale-manager auto-update status   # 查看状态
 ```
+
+（仍兼容旧写法 `on` / `off` / `1` / `0`。）
 
 ### 工作原理
 

--- a/docs/zh/guide/commands.md
+++ b/docs/zh/guide/commands.md
@@ -12,38 +12,46 @@ tailscale-manager [命令] [选项]
 
 ## 命令列表
 
-### 核心命令
+::: tip 两种互相独立的「更新」
+- `update` / `auto-update` 作用于 **Tailscale 二进制**（本工具安装的 VPN 程序）。
+- `self-update` 作用于 **管理器本身**（管理脚本与 LuCI 界面）。
+
+两者完全独立：更新 Tailscale 不会动管理器，`self-update` 也不会动 Tailscale。
+:::
+
+### 核心命令（Tailscale 二进制）
 
 | 命令 | 说明 |
 |------|------|
 | `install` | 交互式安装 Tailscale |
-| `update` | 更新 Tailscale 到最新版本 |
-| `uninstall` | 卸载 Tailscale 及相关文件 |
+| `update [--yes]` | 更新 **Tailscale 二进制** 到最新版本（`--yes` 跳过确认） |
+| `rollback` | 将 **Tailscale 二进制** 回滚到上一个版本 |
+| `uninstall [--yes]` | 卸载 Tailscale 及相关文件（`--yes` 跳过确认） |
 | `status` | 显示当前安装和服务状态 |
 
 ### 安装变体
 
 | 命令 | 说明 |
 |------|------|
-| `install-quiet` | 非交互式安装（适用于脚本自动化） |
+| `install --yes` | 非交互式安装（适用于 LuCI/脚本自动化） |
 | `install-version <版本>` | 安装指定版本 |
 | `download-only` | 仅下载二进制文件，不安装 |
 
 #### 安装选项
 
-`install-quiet` 与 `install-version` 均支持以下参数：
+`install --yes` 与 `install-version` 均支持以下参数：
 
 | 参数 | 可选值 | 说明 |
 |------|--------|------|
 | `--source` | `official` / `small` | 下载源 |
-| `--storage` | `persistent` / `ram` | 存储模式（仅 `install-quiet`） |
-| `--auto-update` | `0` / `1` | 启用每日自动更新定时任务（仅 `install-quiet`） |
+| `--storage` | `persistent` / `ram` | 存储模式（仅 `install --yes`） |
+| `--auto-update` | `0` / `1` | 启用每日 Tailscale 自动更新定时任务（仅 `install --yes`） |
 | `--bin-dir` | 绝对路径 | 持久化模式下的自定义二进制目录（详见[存储模式](/zh/guide/storage-modes#自定义二进制目录)） |
 
 示例：
 
 ```sh
-tailscale-manager install-quiet --source small --bin-dir /mnt/sda1/tailscale
+tailscale-manager install --yes --source small --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 
@@ -51,28 +59,36 @@ tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 
 | 命令 | 说明 |
 |------|------|
-| `list-versions [n]` | 列出可用的 Small 版本（默认：10） |
+| `list-small-versions [n]` | 列出可用的 Small 版本（默认：10） |
 | `list-official-versions [n]` | 列出可用的 Official 版本（默认：20） |
 
 ### 网络配置
 
 | 命令 | 说明 |
 |------|------|
-| `setup-firewall` | 配置 tailscale0 接口和防火墙区域 |
+| `setup-subnet-routing` | 配置 tailscale0 接口和防火墙区域 |
 | `net-mode [auto\|tun\|userspace\|status]` | 获取或设置网络模式 |
 
-### 脚本管理
+### Tailscale 自动更新
 
 | 命令 | 说明 |
 |------|------|
-| `self-update` | 一步重装整个管理层（管理脚本、库文件、LuCI 界面）到最新版本 |
-| `auto-update [on\|off\|status]` | 管理二进制自动更新定时任务 |
+| `auto-update [enable\|disable\|status]` | 管理 **Tailscale 二进制** 的每日自动更新定时任务 |
+
+（仍兼容旧写法 `on`/`off`/`1`/`0`，等价于 `enable`/`disable`。）
+
+### 管理器自更新
+
+| 命令 | 说明 |
+|------|------|
+| `self-update [--yes]` | 一步重装 **管理器本身**（管理脚本、库文件、LuCI 界面）到最新版本，**不会** 改动 Tailscale 二进制 |
 
 ### 其他
 
 | 命令 | 说明 |
 |------|------|
 | `help` | 显示帮助信息 |
+| `--version`、`-v` | 打印管理器版本并退出 |
 
 ## 服务命令
 

--- a/docs/zh/guide/storage-modes.md
+++ b/docs/zh/guide/storage-modes.md
@@ -31,17 +31,17 @@ Binary directory [/opt/tailscale]:
 
 输入任意绝对路径（如 `/mnt/sda1/tailscale`），或直接回车使用默认值。
 
-**非交互式安装** — 使用 `--bin-dir` 参数（注意：交互式 `install` 命令不解析参数，脚本化场景需用 `install-quiet`）：
+**非交互式安装** — 使用 `--bin-dir` 参数（注意：交互式 `install` 命令不解析参数，脚本化场景需用 `install --yes`）：
 
 ```sh
-tailscale-manager install-quiet --bin-dir /mnt/sda1/tailscale
+tailscale-manager install --yes --bin-dir /mnt/sda1/tailscale
 tailscale-manager install-version 1.78.0 --bin-dir /mnt/sda1/tailscale
 ```
 
 **后续更换目录** — 使用新路径再执行一次安装命令即可。Tailscale 状态文件单独保存，这个操作只会替换二进制文件并更新当前配置的二进制目录：
 
 ```sh
-tailscale-manager install-quiet --bin-dir /mnt/sdb1/tailscale
+tailscale-manager install --yes --bin-dir /mnt/sdb1/tailscale
 ```
 
 如果想保持当前已安装的 Tailscale 版本，显式安装该版本：

--- a/docs/zh/guide/subnet-routing.md
+++ b/docs/zh/guide/subnet-routing.md
@@ -7,7 +7,7 @@
 安装过程中会提示是否配置子网路由。也可以之后运行：
 
 ```sh
-tailscale-manager setup-firewall
+tailscale-manager setup-subnet-routing
 ```
 
 这将：
@@ -55,4 +55,4 @@ tailscale up --advertise-exit-node
 
 ## 用户空间模式
 
-在 [用户空间模式](/zh/guide/userspace-mode) 下，不会创建 `tailscale0` 接口，而是通过 SOCKS5 和 HTTP 代理监听来提供连接。不需要执行 `setup-firewall` 命令。
+在 [用户空间模式](/zh/guide/userspace-mode) 下，不会创建 `tailscale0` 接口，而是通过 SOCKS5 和 HTTP 代理监听来提供连接。不需要执行 `setup-subnet-routing` 命令。

--- a/docs/zh/guide/troubleshooting.md
+++ b/docs/zh/guide/troubleshooting.md
@@ -66,7 +66,7 @@ tailscale-manager install
 **解决方案**：配置子网路由：
 
 ```sh
-tailscale-manager setup-firewall
+tailscale-manager setup-subnet-routing
 tailscale set --advertise-routes=192.168.1.0/24
 ```
 

--- a/docs/zh/guide/uninstall.md
+++ b/docs/zh/guide/uninstall.md
@@ -14,7 +14,7 @@ tailscale-manager uninstall
 - UCI 配置（`/etc/config/tailscale`）
 - 模块库（`/usr/lib/tailscale/`）
 - LuCI 界面文件（如已安装）
-- 网络接口和防火墙区域（如通过 `setup-firewall` 配置）
+- 网络接口和防火墙区域（如通过 `setup-subnet-routing` 配置）
 
 ## 保留的文件
 

--- a/docs/zh/guide/userspace-mode.md
+++ b/docs/zh/guide/userspace-mode.md
@@ -62,7 +62,7 @@ tailscale set --advertise-routes=192.168.1.0/24
 ```
 
 ::: warning 限制
-- **不会**创建 `tailscale0` 接口 — 不需要执行 `setup-firewall`。
+- **不会**创建 `tailscale0` 接口 — 不需要执行 `setup-subnet-routing`。
 - 支持 TCP、UDP 和 ICMP（ping），但并非所有 IP 协议。
 - 性能通常低于内核 TUN 模式。
 :::

--- a/luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale
+++ b/luci-app-tailscale/root/usr/libexec/rpcd/luci-tailscale
@@ -283,7 +283,7 @@ call)
             input=$(read_input)
             limit=$(json_get_int_param "$input" limit 2>/dev/null || true)
             [ -n "$limit" ] || limit=20
-            versions=$("$MANAGER_BIN" list-versions "$limit" 2>/dev/null || true)
+            versions=$("$MANAGER_BIN" list-small-versions "$limit" 2>/dev/null || true)
             printf '{"versions":'
             printf '%s\n' "$versions" | json_array_from_lines
             printf '}'
@@ -313,7 +313,7 @@ call)
             source=$(json_get_param "$input" source)
             storage=$(json_get_param "$input" storage)
             auto_update=$(json_get_param "$input" auto_update)
-            set -- "$MANAGER_BIN" install-quiet
+            set -- "$MANAGER_BIN" install --yes
             [ -n "$source" ] && set -- "$@" --source "$source"
             [ -n "$storage" ] && set -- "$@" --storage "$storage"
             [ -n "$auto_update" ] && set -- "$@" --auto-update "$auto_update"
@@ -328,7 +328,7 @@ call)
             start_background_task install-version "$@"
             ;;
         do_update)
-            start_background_task update "$MANAGER_BIN" update --auto
+            start_background_task update "$MANAGER_BIN" update --yes
             ;;
         do_uninstall)
             stdout=$("$MANAGER_BIN" uninstall --yes 2>&1)
@@ -354,7 +354,7 @@ call)
             print_code_stdout "$code" "$stdout"
             ;;
         upgrade_scripts)
-            start_background_task upgrade-scripts "$MANAGER_BIN" self-update --non-interactive
+            start_background_task upgrade-scripts "$MANAGER_BIN" self-update --yes
             ;;
         get_logs)
             manager_log=""

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.3.0"
+VERSION="4.4.0"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)
@@ -769,7 +769,7 @@ main() {
     # any unrecognised argument fell through to check_script_update first, which
     # made bogus commands look like they "did something".
     case "${1:-}" in
-        install|update|rollback|uninstall|status|download-only|install-quiet|install-version|list-versions|list-official-versions|setup-firewall|self-update|auto-update|net-mode|json-status|json-install-info|json-latest-versions|json-latest-version|json-script-local-info|json-script-info|-h|--help|help|-v|--version|"") ;;
+        install|update|rollback|uninstall|status|download-only|install-version|list-small-versions|list-official-versions|setup-subnet-routing|self-update|auto-update|net-mode|json-status|json-install-info|json-latest-versions|json-latest-version|json-script-local-info|json-script-info|-h|--help|help|-v|--version|"") ;;
         *)
             echo "Unknown command: $1"
             echo "Run '$0 help' for usage"
@@ -796,7 +796,18 @@ main() {
 
     case "${1:-}" in
         install)
-            do_install
+            # Bare `install` runs the interactive flow. Any arguments switch to
+            # the non-interactive path (for LuCI/automation); a leading --yes/-y
+            # is accepted and stripped so it matches the rest of the CLI.
+            shift
+            if [ "$#" -eq 0 ]; then
+                do_install
+            else
+                case "${1:-}" in
+                    --yes|-y) shift ;;
+                esac
+                cmd_install "$@"
+            fi
             ;;
         update)
             do_update "$2"
@@ -813,21 +824,17 @@ main() {
         download-only)
             do_download_only
             ;;
-        install-quiet)
-            shift
-            cmd_install "$@"
-            ;;
         install-version)
             shift
             cmd_install_version "$@"
             ;;
-        list-versions)
+        list-small-versions)
             list_small_versions "${2:-10}"
             ;;
         list-official-versions)
             list_official_versions "${2:-20}"
             ;;
-        setup-firewall)
+        setup-subnet-routing)
             do_setup_subnet_routing
             ;;
         self-update)
@@ -849,11 +856,14 @@ main() {
             esac
             ;;
         auto-update)
+            # Scheduled automatic updates of the Tailscale binary (cron).
+            # Canonical values are enable|disable|status; on/off/1/0 stay
+            # accepted for backward compatibility. The UCI value remains 0/1.
             case "${2:-status}" in
-                on|enable|1)
+                enable|on|1)
                     configure_auto_update "1"
                     ;;
-                off|disable|0)
+                disable|off|0)
                     configure_auto_update "0"
                     ;;
                 reconcile)
@@ -861,7 +871,7 @@ main() {
                     ;;
                 status|"")
                     echo ""
-                    echo "Auto-update status:"
+                    echo "Tailscale auto-update status:"
                     if [ "$(get_auto_update_config)" = "1" ]; then
                         if crontab -l 2>/dev/null | grep -Fq "$CRON_SCRIPT"; then
                             echo "  Enabled (cron active)"
@@ -874,7 +884,7 @@ main() {
                     echo ""
                     ;;
                 *)
-                    echo "Usage: $0 auto-update [on|off|status]"
+                    echo "Usage: $0 auto-update [enable|disable|status]"
                     exit 1
                     ;;
             esac
@@ -929,23 +939,32 @@ main() {
             echo ""
             echo "Usage: $0 [command]"
             echo ""
-            echo "Commands:"
-            echo "  install          Install Tailscale (interactive)"
-            echo "  install-quiet    Install Tailscale (non-interactive, for LuCI/automation)"
-            echo "  install-version  Install specific version (non-interactive)"
-            echo "  update           Update to latest version"
-            echo "  rollback         Roll back to previous version"
-            echo "  uninstall        Remove Tailscale (use --yes to skip confirmation)"
-            echo "  status           Show current status"
-            echo "  list-versions    List available small binary versions"
-            echo "  list-official-versions List available official package versions"
-            echo "  setup-firewall   Configure network interface and firewall for subnet routing"
-            echo "  download-only    Download binaries only (for RAM mode)"
-            echo "  self-update      Reinstall the management layer (scripts + LuCI) to the latest version"
-            echo "  auto-update      Configure auto-update (on/off/status)"
-            echo "  net-mode         Configure networking mode (auto/tun/userspace/status)"
-            echo "  help             Show this help"
-            echo "  --version        Print the manager version and exit"
+            echo "Tailscale commands (manage the Tailscale binary this tool installs):"
+            echo "  install                      Install Tailscale (interactive)"
+            echo "  install --yes [options]      Install Tailscale (non-interactive, for LuCI/automation)"
+            echo "  install-version <ver>        Install a specific Tailscale version (non-interactive)"
+            echo "  update [--yes]               Update the Tailscale binary to the latest version"
+            echo "  rollback                     Roll back the Tailscale binary to the previous version"
+            echo "  auto-update <enable|disable|status>"
+            echo "                               Schedule automatic Tailscale binary updates (cron)"
+            echo "  status                       Show Tailscale install and runtime status"
+            echo "  list-small-versions [n]      List available small (compressed) Tailscale versions"
+            echo "  list-official-versions [n]   List available official Tailscale versions"
+            echo "  download-only                Download Tailscale binaries only (for RAM mode)"
+            echo "  setup-subnet-routing         Configure interface/firewall for subnet routing"
+            echo "  net-mode <auto|tun|userspace|status>"
+            echo "                               Configure Tailscale networking mode"
+            echo "  uninstall [--yes]            Remove Tailscale"
+            echo ""
+            echo "Manager command (manages this tool itself, NOT the Tailscale binary):"
+            echo "  self-update [--yes]          Reinstall this manager (scripts + LuCI) to the latest version"
+            echo ""
+            echo "Other:"
+            echo "  help                         Show this help"
+            echo "  -v, --version                Print the manager version and exit"
+            echo ""
+            echo "Note: 'update'/'auto-update' act on the Tailscale binary; 'self-update'"
+            echo "      acts on this manager. They are independent of each other."
             echo ""
             echo "Environment variables:"
             echo "  TAILSCALE_SOURCE=official|small"

--- a/tests/bats/cli/unknown.bats
+++ b/tests/bats/cli/unknown.bats
@@ -49,3 +49,21 @@ exit 1"
 
     [ ! -f "${TEST_DIR}/wget-called" ] || { echo "removed command must not access the network"; false; }
 }
+
+@test "main rejects renamed-away commands (hard rename)" {
+    bin_stub wget "#!/bin/sh
+touch '${TEST_DIR}/wget-called'
+exit 1"
+
+    for old in install-quiet list-versions setup-firewall; do
+        run env PATH="${STUB_BIN}:${PATH}" \
+            LIB_DIR="${REPO_ROOT}/usr/lib/tailscale" \
+            LOG_FILE="${TEST_DIR}/tailscale-manager.log" \
+            sh "${REPO_ROOT}/tailscale-manager.sh" "$old" </dev/null
+
+        assert_failure
+        assert_output --partial "Unknown command: $old"
+    done
+
+    [ ! -f "${TEST_DIR}/wget-called" ] || { echo "renamed-away command must not access the network"; false; }
+}

--- a/tests/bats/deploy/install.bats
+++ b/tests/bats/deploy/install.bats
@@ -109,7 +109,7 @@ fi
     assert_success
 }
 
-@test "install-quiet deploys LuCI app files" {
+@test "install --yes deploys LuCI app files" {
     run_in_sh auto "$(_install_stubs)
 
 cmd_install --source official --storage ram --auto-update 1 >/dev/null
@@ -125,7 +125,7 @@ grep -Fq 'init start' \"\$INIT_CALLS_LOG\"
     assert_success
 }
 
-@test "install-quiet honors --bin-dir flag for persistent mode" {
+@test "install --yes honors --bin-dir flag for persistent mode" {
     local custom_dir="${TEST_DIR}/root/mnt/sda1/tailscale"
 
     run_in_sh auto "$(_install_stubs)
@@ -143,7 +143,7 @@ grep -Fq \"uci persistent \$custom_dir official 0\" \"\$CALLS\" || {
     assert_success
 }
 
-@test "install-quiet rejects relative --bin-dir" {
+@test "install --yes rejects relative --bin-dir" {
     run_in_sh auto "$(_install_stubs)
 
 if cmd_install --bin-dir relative/path >/dev/null 2>&1; then
@@ -154,7 +154,7 @@ fi
     assert_success
 }
 
-@test "install-quiet rejects reserved system --bin-dir" {
+@test "install --yes rejects reserved system --bin-dir" {
     run_in_sh auto "$(_install_stubs)
 
 for bad in / /etc /usr /usr/bin; do
@@ -167,7 +167,7 @@ done
     assert_success
 }
 
-@test "install-quiet rejects missing option values" {
+@test "install --yes rejects missing option values" {
     run_in_sh auto "$(_install_stubs)
 
 for args in '--source' '--storage' '--auto-update' '--bin-dir'; do
@@ -181,7 +181,7 @@ done
     assert_success
 }
 
-@test "install-quiet rejects invalid option values" {
+@test "install --yes rejects invalid option values" {
     run_in_sh auto "$(_install_stubs)
 
 if cmd_install --source --storage >/dev/null 2>&1; then
@@ -204,7 +204,7 @@ fi
     assert_success
 }
 
-@test "install-quiet rejects unsafe PERSISTENT_DIR env" {
+@test "install --yes rejects unsafe PERSISTENT_DIR env" {
     run_in_sh auto "$(_install_stubs)
 PERSISTENT_DIR='/'
 
@@ -216,7 +216,7 @@ fi
     assert_success
 }
 
-@test "install-quiet rejects unsafe configured bin_dir from uci" {
+@test "install --yes rejects unsafe configured bin_dir from uci" {
     run_in_sh auto "$(_install_stubs)
 
 if require_configured_persistent_bin_dir /usr >/dev/null 2>&1; then

--- a/tests/bats/rpcd/dispatch.bats
+++ b/tests/bats/rpcd/dispatch.bats
@@ -49,7 +49,7 @@ MSCRIPT
 output=\$(printf '{\"source\":\"small\",\"storage\":\"ram\",\"auto_update\":\"1\"}' | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${REPO_ROOT}/usr/lib/tailscale' sh '${BRIDGE}' call do_install)
 printf '%s' \"\$output\" | grep -Fq '\"started\":true' || { echo 'missing started: '\$output; exit 1; }
 sleep 1
-grep -Fq 'install-quiet --source small --storage ram --auto-update 1' '${TEST_DIR}/manager-call' || {
+grep -Fq 'install --yes --source small --storage ram --auto-update 1' '${TEST_DIR}/manager-call' || {
     echo 'wrong manager call'
     cat '${TEST_DIR}/manager-call'
     exit 1
@@ -173,7 +173,7 @@ task=\$(printf '%s' \"\$start\" | sed -n 's/.*\"task\":\"\([^\"]*\)\".*/\1/p')
 sleep 1
 status=\$(printf '{\"task\":\"%s\"}' \"\$task\" | MANAGER_BIN='${MANAGER}' TASK_DIR='${TASK_DIR}' LIB_DIR='${LIB_DIR_TEST}' sh '${BRIDGE}' call get_task_status)
 printf '%s' \"\$status\" | grep -Fq '\"done\":true' || { echo 'missing done'; exit 1; }
-grep -Fq 'self-update --non-interactive' '${TEST_DIR}/manager-call' || {
+grep -Fq 'self-update --yes' '${TEST_DIR}/manager-call' || {
     echo 'wrong manager call'
     cat '${TEST_DIR}/manager-call'
     exit 1

--- a/tests/bats/selfupdate/bundle.bats
+++ b/tests/bats/selfupdate/bundle.bats
@@ -85,7 +85,7 @@ wget() {
 
 setup_cron() { :; }
 
-do_self_update --non-interactive >/dev/null 2>&1 || {
+do_self_update --yes >/dev/null 2>&1 || {
     echo 'self-update failed'
     exit 1
 }
@@ -127,7 +127,7 @@ wget() {
     return 1
 }
 
-if do_self_update --non-interactive >/dev/null 2>&1; then
+if do_self_update --yes >/dev/null 2>&1; then
     echo 'self-update accepted checksum mismatch'
     exit 1
 fi
@@ -193,7 +193,7 @@ tar() {
     command tar \"\$@\"
 }
 
-if do_self_update --non-interactive >/dev/null 2>&1; then
+if do_self_update --yes >/dev/null 2>&1; then
     echo 'self-update accepted unsafe archive member'
     exit 1
 fi

--- a/tests/bats/selfupdate/guard.bats
+++ b/tests/bats/selfupdate/guard.bats
@@ -61,10 +61,10 @@ export MANAGER_BIN_PATH
 get_remote_script_version() { echo '9.9.9'; }
 do_self_update() { return 0; }
 
-( check_script_update --non-interactive ) >/dev/null 2>&1
+( check_script_update --yes ) >/dev/null 2>&1
 
 [ -f '${TEST_DIR}/reexec.log' ] || { echo 'stub manager was not invoked'; exit 1; }
-grep -q '^argv: \[--non-interactive\]$' '${TEST_DIR}/reexec.log' || {
+grep -q '^argv: \[--yes\]$' '${TEST_DIR}/reexec.log' || {
     echo 'argv not preserved across re-exec'
     cat '${TEST_DIR}/reexec.log'
     exit 1
@@ -104,9 +104,9 @@ export MANAGER_BIN_PATH
 get_remote_script_version() { echo '9.9.9'; }
 do_self_update() { return 0; }
 
-( main self-update --non-interactive ) >/dev/null 2>&1
+( main self-update --yes ) >/dev/null 2>&1
 
-grep -q '^argv: \[self-update\] \[--non-interactive\]$' '${TEST_DIR}/main-reexec.log' || {
+grep -q '^argv: \[self-update\] \[--yes\]$' '${TEST_DIR}/main-reexec.log' || {
     echo 'self-update argv mismatch across re-exec'
     cat '${TEST_DIR}/main-reexec.log'
     exit 1
@@ -127,7 +127,7 @@ LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
 TAILSCALE_MANAGER_REEXEC=1
 export LIB_DIR TAILSCALE_MANAGER_REEXEC
 
-sh '${REPO_ROOT}/tailscale-manager.sh' self-update --non-interactive > '${TEST_DIR}/reexeced.out' 2>&1 || {
+sh '${REPO_ROOT}/tailscale-manager.sh' self-update --yes > '${TEST_DIR}/reexeced.out' 2>&1 || {
     cat '${TEST_DIR}/reexeced.out'
     exit 1
 }
@@ -160,7 +160,7 @@ get_remote_script_version() { echo '9.9.9'; }
 do_self_update() { return 0; }
 
 rc=0
-check_script_update --non-interactive >/dev/null 2>&1 || rc=\$?
+check_script_update --yes >/dev/null 2>&1 || rc=\$?
 [ \"\$rc\" -eq 0 ] || { echo \"expected rc=0, got \$rc\"; exit 1; }
 " < /dev/null
     assert_success
@@ -181,7 +181,7 @@ get_remote_script_version() { echo '9.9.9'; }
 do_self_update() { return 0; }
 
 rc=0
-check_script_update --non-interactive >/dev/null 2>&1 || rc=\$?
+check_script_update --yes >/dev/null 2>&1 || rc=\$?
 [ \"\$rc\" -eq 0 ] || { echo \"expected rc=0, got \$rc\"; exit 1; }
 " < /dev/null
     assert_success

--- a/usr/bin/tailscale-update
+++ b/usr/bin/tailscale-update
@@ -115,7 +115,7 @@ fi
 
 log_msg "Update available: v${CURRENT_VERSION} -> v${LATEST_VERSION} (source: ${DOWNLOAD_SOURCE})"
 
-if "$TAILSCALE_MANAGER_BIN" update --auto; then
+if "$TAILSCALE_MANAGER_BIN" update --yes; then
     log_msg "Update successful"
 else
     log_msg "Update failed"

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -399,7 +399,7 @@ do_install() {
             *)
                 echo ""
                 echo "Skipped. You can configure later with:"
-                echo "  tailscale-manager setup-firewall"
+                echo "  tailscale-manager setup-subnet-routing"
                 echo ""
                 ;;
         esac
@@ -417,14 +417,14 @@ do_install() {
     echo "Useful commands:"
     echo "  tailscale status       - Check connection status"
     echo "  tailscale up --help    - See all options"
-    echo "  tailscale-manager setup-firewall - Configure subnet routing"
+    echo "  tailscale-manager setup-subnet-routing - Configure subnet routing"
     echo ""
 }
 
 do_update() {
-    local auto_mode="${1:-}"
+    local non_interactive="${1:-}"
 
-    log_info "Checking for updates..."
+    log_info "Checking for Tailscale updates..."
 
     [ -r /lib/functions.sh ] && . /lib/functions.sh
     config_load tailscale
@@ -457,7 +457,7 @@ do_update() {
         return 0
     fi
 
-    if [ "$auto_mode" != "--auto" ]; then
+    if [ "$non_interactive" != "--yes" ]; then
         printf 'Update to v%s? [y/N]: ' "$latest_version"
         read -r answer
         case "$answer" in

--- a/usr/lib/tailscale/firewall.sh
+++ b/usr/lib/tailscale/firewall.sh
@@ -274,7 +274,7 @@ do_setup_subnet_routing() {
             ;;
         *)
             echo "Skipped firewall zone creation."
-            echo "If subnet routing doesn't work, run: tailscale-manager setup-firewall"
+            echo "If subnet routing doesn't work, run: tailscale-manager setup-subnet-routing"
             ;;
     esac
 

--- a/usr/lib/tailscale/selfupdate.sh
+++ b/usr/lib/tailscale/selfupdate.sh
@@ -122,7 +122,7 @@ _reexec_into_new_manager() {
 check_script_update() {
     local non_interactive=0
     case " ${*:-} " in
-        *" --non-interactive "*) non_interactive=1 ;;
+        *" --yes "*) non_interactive=1 ;;
     esac
 
     if [ "$non_interactive" -ne 1 ]; then


### PR DESCRIPTION
## Summary

Hard-rename ambiguous CLI commands/parameters so it is always clear whether an action targets the **Tailscale binary** or the **management scripts themselves**. UCI parameters are unchanged (compatibility standard).

**Command renames (old names removed):**
- `install-quiet` → `install --yes` (bare `install` = interactive; args / leading `--yes`/`-y` = non-interactive)
- `setup-firewall` → `setup-subnet-routing`
- `list-versions` → `list-small-versions`
- `update --auto` → `update --yes`
- `self-update --non-interactive` → `self-update --yes`
- `auto-update on|off` → `auto-update enable|disable|status` (legacy `on/off/1/0` still accepted; UCI value stays `0/1`)

**Clarity:** `help` is now grouped by target with a cross-reference note, so `update`/`auto-update` (Tailscale binary) are never confused with `self-update` (this manager).

**Propagation:** rpcd bridge, cron (`tailscale-update`), tests, and docs (zh + en) updated to the new tokens. RPC method names (internal interface) unchanged. `VERSION` → 4.4.0.

## Upgrade safety

- Self-update reinstalls the whole management layer, including `usr/bin/tailscale-update`, so an old cron calling `update --auto` is overwritten with the new `update --yes` one — no silent auto-update breakage. (`deploy.sh` is unchanged and identical in 4.3.0, so the old code that performs the self-update already replaces the cron.)
- `/etc/config/tailscale` (UCI) is never touched by self-update; `bin_dir`/`storage_mode`/`download_source`/`auto_update`/`net_mode`/`extra_*` all survive the upgrade.

## Test plan

- [x] `make lint` (syntax + check-sync + shellcheck + check-static) passes
- [x] `make test` — 184/184 pass
- [x] `tailscale-manager --version` → `4.4.0`; `help` output grouped and clear
- [x] `cli/unknown.bats` asserts `install-quiet` / `list-versions` / `setup-firewall` are now rejected without a network call
- [x] Code review (functional / logging / upgrade-config-preservation): all PASS, no bugs
