### PR TITLE
feat(cli): add logs and diagnostics commands and broaden log coverage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -100,12 +100,17 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Relevant logs
+      label: Relevant logs / diagnostics
       description: |
-        Useful sources:
+        The fastest way to give us everything we need is one command:
+
+        - `tailscale-manager diagnostics` — full report (versions, platform, install/runtime state, dependency checks, and recent logs). Paste the whole output.
+
+        Or, if you only need the raw logs:
+
+        - `tailscale-manager logs` — last 200 lines of the manager, service, and system logs at once
         - `logread -e tailscale | tail -200`
         - `tail -200 /var/log/tailscale-manager.log`
-        - `tailscale-manager status`
       render: shell
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Then follow the interactive prompts.
 - **Userspace fallback** — works even without kernel TUN support
 - **RAM mode** — run entirely from `/tmp` for devices with minimal flash storage
 - **LuCI management UI** — status monitoring, service control, version management, and log viewer
+- **One-command diagnostics** — `tailscale-manager diagnostics` gathers everything a bug report needs in a single paste-ready block
 
 ## Documentation
 

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,6 +2,15 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.5.0 (2026-06-07)
+
+- Added `tailscale-manager diagnostics` (alias `doctor`): a one-shot troubleshooting report (versions, device/system info, install & runtime state, dependency and HTTPS-reachability checks, UCI config, recent logs) that mirrors the bug report template fields and can be pasted straight into an issue
+- Added `tailscale-manager logs [n]`: view the last n lines of the manager / service / auto-update / system (`logread`) logs at once (default 200) — no more remembering individual paths
+- The interactive menu gained a "Collect Diagnostics" entry that also saves the report to `/tmp/tailscale-diagnostics.txt`
+- Better log coverage: rollback, uninstall, RAM-mode download (`download-only`), and library bootstrap now log their key steps; state-changing commands (install/update/uninstall/…) leave an invocation breadcrumb in the manager log
+- `LOG_FILE` is now overridable via the environment so the manager log can live on persistent storage instead of `/var/log` (tmpfs), which is wiped on reboot
+- The issue template and troubleshooting docs now point to the `diagnostics` / `logs` commands
+
 ## v4.4.0 (2026-06-07)
 
 - Clearer separation between updating the **Tailscale binary** (`update`, `auto-update`) and updating **the manager itself** (`self-update`); `help` is now grouped by target so the two can no longer be confused

--- a/docs/en/guide/commands.md
+++ b/docs/en/guide/commands.md
@@ -29,6 +29,18 @@ They are completely independent: updating Tailscale never touches the manager, a
 | `uninstall [--yes]` | Remove Tailscale and all related files (`--yes` skips the prompt) |
 | `status` | Show current installation and service status |
 
+### Diagnostics & Troubleshooting
+
+| Command | Description |
+|---------|-------------|
+| `logs [n]` | Show the last n lines of the manager, service, and system logs at once (default 200) |
+| `diagnostics` | Print a full troubleshooting report (versions, platform, install/runtime state, dependency checks, UCI config, and recent logs) ready to paste into an issue (alias: `doctor`) |
+
+```sh
+tailscale-manager diagnostics        # run this before opening an issue
+tailscale-manager logs 500           # show the last 500 log lines
+```
+
 ### Installation Variants
 
 | Command | Description |

--- a/docs/en/guide/troubleshooting.md
+++ b/docs/en/guide/troubleshooting.md
@@ -1,12 +1,38 @@
 # Troubleshooting
 
+## One-shot diagnostics (recommended)
+
+When troubleshooting anything — or before opening an issue — run:
+
+```sh
+tailscale-manager diagnostics
+```
+
+It collects the versions, device/system info, install and runtime state, dependency checks, UCI config, and recent log excerpts in a single block you can paste straight into a [GitHub Issue](https://github.com/fl0w1nd/openwrt-tailscale/issues) (`doctor` is an alias).
+
+If you only want the logs:
+
+```sh
+tailscale-manager logs        # manager, service, and system logs at once (last 200 lines)
+tailscale-manager logs 500    # custom line count
+```
+
 ## Log Files
 
 | Log | Location | Content |
 |-----|----------|---------|
-| Manager log | `/var/log/tailscale-manager.log` | Install, update, and script operations |
+| Manager log | `/var/log/tailscale-manager.log` | Install, update, uninstall, rollback, and script operations |
 | Service log | `/var/log/tailscale.log` | Tailscale daemon output |
-| System log | `logread \| grep tailscale` | procd service events |
+| Auto-update log | `/var/log/tailscale-update.log` | Scheduled Tailscale binary updates (cron) |
+| System log | `logread -e tailscale` | procd service events |
+
+::: tip Logs live under `/var/log` (usually tmpfs) and are wiped on reboot.
+To keep the manager log across reboots, set the `LOG_FILE` environment variable to a persistent path, e.g.:
+
+```sh
+LOG_FILE=/etc/tailscale/manager.log tailscale-manager status
+```
+:::
 
 ## Common Issues
 
@@ -75,4 +101,5 @@ Then approve the route in the [Tailscale Admin Console](https://login.tailscale.
 ## Getting Help
 
 - [GitHub Issues](https://github.com/fl0w1nd/openwrt-tailscale/issues) — Report bugs or request features
-- Check `tailscale-manager status` for a quick diagnostic overview
+- Before filing an issue, attach the full output of `tailscale-manager diagnostics`
+- Run `tailscale-manager status` for a quick install/runtime overview

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,6 +2,15 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.5.0 (2026-06-07)
+
+- 新增 `tailscale-manager diagnostics`（别名 `doctor`）：一键生成完整排查报告（版本、设备/系统信息、安装与运行状态、依赖与 HTTPS 连通性检查、UCI 配置、最近日志），与 issue 模板字段一一对应，提交 issue 时可直接粘贴
+- 新增 `tailscale-manager logs [n]`：一次性查看管理器 / 服务 / 自动更新 / 系统（`logread`）日志的最近 n 行（默认 200），不必再逐个记忆路径
+- 交互菜单新增「Collect Diagnostics」，并把诊断报告同时保存到 `/tmp/tailscale-diagnostics.txt`
+- 完善日志覆盖：回滚、卸载、内存模式下载（download-only）、库文件引导等关键节点补齐日志；状态变更类命令（install/update/uninstall/…）在管理器日志中留下调用记录
+- `LOG_FILE` 现支持环境变量覆盖，可把管理器日志放到持久化目录，避免 `/var/log`（tmpfs）重启清空导致排查无据
+- issue 模板与故障排查文档改为推荐 `diagnostics` / `logs` 命令
+
 ## v4.4.0 (2026-06-07)
 
 - 明确区分「更新 **Tailscale 二进制**」（`update`、`auto-update`）与「更新 **管理器本身**」（`self-update`）；`help` 现按作用对象分组，两者不再混淆

--- a/docs/zh/guide/commands.md
+++ b/docs/zh/guide/commands.md
@@ -29,6 +29,18 @@ tailscale-manager [命令] [选项]
 | `uninstall [--yes]` | 卸载 Tailscale 及相关文件（`--yes` 跳过确认） |
 | `status` | 显示当前安装和服务状态 |
 
+### 诊断与排查
+
+| 命令 | 说明 |
+|------|------|
+| `logs [n]` | 一次性查看管理器、服务、系统三类日志的最近 n 行（默认 200） |
+| `diagnostics` | 输出完整排查报告（版本、平台、安装/运行状态、依赖检查、UCI 配置与最近日志），便于直接粘贴到 issue（别名：`doctor`） |
+
+```sh
+tailscale-manager diagnostics        # 提交 issue 前先运行这条
+tailscale-manager logs 500           # 查看最近 500 行日志
+```
+
 ### 安装变体
 
 | 命令 | 说明 |

--- a/docs/zh/guide/troubleshooting.md
+++ b/docs/zh/guide/troubleshooting.md
@@ -1,12 +1,38 @@
 # 故障排查
 
+## 一键诊断（推荐）
+
+排查任何问题、或在提交 issue 前，先运行：
+
+```sh
+tailscale-manager diagnostics
+```
+
+它会一次性收集版本、设备/系统信息、安装与运行状态、依赖检查、UCI 配置以及最近的日志片段，整段内容可直接粘贴到 [GitHub Issue](https://github.com/fl0w1nd/openwrt-tailscale/issues)（`doctor` 是它的别名）。
+
+只想看日志时：
+
+```sh
+tailscale-manager logs        # 一次性查看管理器、服务、系统三类日志（默认最近 200 行）
+tailscale-manager logs 500    # 自定义行数
+```
+
 ## 日志文件
 
 | 日志 | 位置 | 内容 |
 |------|------|------|
-| 管理器日志 | `/var/log/tailscale-manager.log` | 安装、更新和脚本操作 |
+| 管理器日志 | `/var/log/tailscale-manager.log` | 安装、更新、卸载、回滚等脚本操作 |
 | 服务日志 | `/var/log/tailscale.log` | Tailscale 守护进程输出 |
-| 系统日志 | `logread \| grep tailscale` | procd 服务事件 |
+| 自动更新日志 | `/var/log/tailscale-update.log` | 定时任务的 Tailscale 二进制更新 |
+| 系统日志 | `logread -e tailscale` | procd 服务事件 |
+
+::: tip 日志默认存放在 `/var/log`（通常为 tmpfs），重启后会清空。
+如需让管理器日志在重启后保留，可设置环境变量 `LOG_FILE` 指向持久化路径，例如：
+
+```sh
+LOG_FILE=/etc/tailscale/manager.log tailscale-manager status
+```
+:::
 
 ## 常见问题
 
@@ -75,4 +101,5 @@ tailscale set --advertise-routes=192.168.1.0/24
 ## 获取帮助
 
 - [GitHub Issues](https://github.com/fl0w1nd/openwrt-tailscale/issues) — 报告问题或提出功能请求
-- 运行 `tailscale-manager status` 快速诊断概览
+- 提交 issue 前，请附上 `tailscale-manager diagnostics` 的完整输出
+- 运行 `tailscale-manager status` 可快速查看安装与运行概览

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.4.0"
+VERSION="4.5.0"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)
@@ -72,7 +72,10 @@ STATE_DIR="/etc/tailscale"
 CONFIG_FILE="/etc/config/tailscale"
 INIT_SCRIPT="/etc/init.d/tailscale"
 CRON_SCRIPT="/usr/bin/tailscale-update"
-LOG_FILE="/var/log/tailscale-manager.log"
+# LOG_FILE can be overridden via env var, e.g. to keep the manager log on
+# persistent storage (the default /var/log is usually tmpfs and is wiped on
+# reboot, which makes after-the-fact troubleshooting harder).
+LOG_FILE="${LOG_FILE:-/var/log/tailscale-manager.log}"
 MANAGER_BIN_PATH="${TAILSCALE_MANAGER_BIN_PATH:-/usr/bin/tailscale-manager}"
 
 # Project repository raw base URL
@@ -430,6 +433,7 @@ _ensure_libraries() {
         # shellcheck source=/dev/null
         . "$LIB_DIR/$_lib"
     done
+    log_info "Bootstrapped runtime libraries into ${LIB_DIR}"
 }
 
 # ============================================================================
@@ -769,7 +773,7 @@ main() {
     # any unrecognised argument fell through to check_script_update first, which
     # made bogus commands look like they "did something".
     case "${1:-}" in
-        install|update|rollback|uninstall|status|download-only|install-version|list-small-versions|list-official-versions|setup-subnet-routing|self-update|auto-update|net-mode|json-status|json-install-info|json-latest-versions|json-latest-version|json-script-local-info|json-script-info|-h|--help|help|-v|--version|"") ;;
+        install|update|rollback|uninstall|status|logs|diagnostics|doctor|download-only|install-version|list-small-versions|list-official-versions|setup-subnet-routing|self-update|auto-update|net-mode|json-status|json-install-info|json-latest-versions|json-latest-version|json-script-local-info|json-script-info|-h|--help|help|-v|--version|"") ;;
         *)
             echo "Unknown command: $1"
             echo "Run '$0 help' for usage"
@@ -793,6 +797,16 @@ main() {
     # explicit action (`self-update`, the interactive-menu reminder, or the
     # LuCI button). Unrelated commands stay fully offline.
     unset TAILSCALE_MANAGER_REEXEC
+
+    # Record state-changing invocations to the manager log so a later
+    # `diagnostics`/`logs` dump shows which commands ran in what order. This is
+    # file-only (no console/syslog noise) and skips read-only/JSON commands so
+    # frequent LuCI polling never floods the log.
+    case "${1:-}" in
+        install|update|rollback|uninstall|install-version|download-only|setup-subnet-routing|self-update|auto-update|net-mode)
+            log_file "INFO" "Command invoked: $0 $*"
+            ;;
+    esac
 
     case "${1:-}" in
         install)
@@ -820,6 +834,12 @@ main() {
             ;;
         status)
             do_status
+            ;;
+        logs)
+            do_logs "$2"
+            ;;
+        diagnostics|doctor)
+            do_diagnostics "$2"
             ;;
         download-only)
             do_download_only
@@ -955,6 +975,11 @@ main() {
             echo "  net-mode <auto|tun|userspace|status>"
             echo "                               Configure Tailscale networking mode"
             echo "  uninstall [--yes]            Remove Tailscale"
+            echo ""
+            echo "Diagnostics & troubleshooting:"
+            echo "  logs [n]                     Show recent manager/service/system logs (default ${TS_LOG_DEFAULT_LINES:-200} lines)"
+            echo "  diagnostics                  Print a full troubleshooting report to paste into a bug report"
+            echo "                               (alias: doctor)"
             echo ""
             echo "Manager command (manages this tool itself, NOT the Tailscale binary):"
             echo "  self-update [--yes]          Reinstall this manager (scripts + LuCI) to the latest version"

--- a/tests/bats/cli/diagnostics.bats
+++ b/tests/bats/cli/diagnostics.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# tests/bats/cli/diagnostics.bats
+# Covers the `logs` and `diagnostics` (alias `doctor`) entry points added so
+# that bug reporters have a single command to gather troubleshooting data.
+
+load ../_lib/load
+
+setup() {
+    setup_test_env
+    # Diagnostics probes HTTPS reachability with wget; stub it so the test
+    # never touches the network. A non-zero exit makes the report show the
+    # "FAILED" branch deterministically.
+    bin_stub wget "#!/bin/sh
+exit 1"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+run_manager() {
+    run env PATH="${STUB_BIN}:${PATH}" \
+        LIB_DIR="${REPO_ROOT}/usr/lib/tailscale" \
+        LOG_FILE="${MANAGER_LOG}" \
+        sh "${REPO_ROOT}/tailscale-manager.sh" "$@" </dev/null
+}
+
+@test "logs prints every log section and reads the manager log" {
+    MANAGER_LOG="${TEST_DIR}/manager.log"
+    printf 'MGR-LINE-1\nMGR-LINE-2\nMGR-LINE-3\n' > "${MANAGER_LOG}"
+
+    run_manager logs
+
+    assert_success
+    assert_output --partial "Tailscale Logs (last 200 lines)"
+    assert_output --partial "Manager log (${MANAGER_LOG})"
+    assert_output --partial "MGR-LINE-3"
+    assert_output --partial "Service log (/var/log/tailscale.log)"
+    assert_output --partial "Auto-update log (/var/log/tailscale-update.log)"
+    assert_output --partial "System log (logread, tailscale)"
+}
+
+@test "logs respects a custom line count" {
+    MANAGER_LOG="${TEST_DIR}/manager.log"
+    printf 'ROW-1\nROW-2\nROW-3\nROW-4\nROW-5\n' > "${MANAGER_LOG}"
+
+    run_manager logs 2
+
+    assert_success
+    assert_output --partial "Tailscale Logs (last 2 lines)"
+    assert_output --partial "ROW-4"
+    assert_output --partial "ROW-5"
+    refute_output --partial "ROW-1"
+}
+
+@test "diagnostics prints a full report with the expected sections" {
+    MANAGER_LOG="${TEST_DIR}/manager.log"
+    : > "${MANAGER_LOG}"
+
+    run_manager diagnostics
+
+    assert_success
+    assert_output --partial "Tailscale Manager Diagnostics"
+    assert_output --partial "[Manager]"
+    assert_output --partial "[System]"
+    assert_output --partial "[Tailscale]"
+    assert_output --partial "[Service]"
+    assert_output --partial "[Dependencies]"
+    assert_output --partial "End of diagnostics"
+
+    expected=$(sed -n 's/^VERSION="\([^"]*\)"/\1/p' "${REPO_ROOT}/tailscale-manager.sh" | head -1)
+    assert_output --partial "Version:        ${expected}"
+}
+
+@test "doctor is an alias for diagnostics" {
+    MANAGER_LOG="${TEST_DIR}/manager.log"
+    : > "${MANAGER_LOG}"
+
+    run_manager doctor
+
+    assert_success
+    assert_output --partial "Tailscale Manager Diagnostics"
+    assert_output --partial "End of diagnostics"
+}
+
+@test "diagnostics reports failed HTTPS reachability when wget cannot connect" {
+    MANAGER_LOG="${TEST_DIR}/manager.log"
+    : > "${MANAGER_LOG}"
+
+    run_manager diagnostics
+
+    assert_success
+    assert_output --partial "HTTPS reachability: FAILED"
+}

--- a/usr/lib/tailscale/commands.sh
+++ b/usr/lib/tailscale/commands.sh
@@ -581,9 +581,12 @@ do_rollback() {
         *) echo "Rollback cancelled."; return 0 ;;
     esac
 
+    log_info "Rolling back Tailscale from v${current_version} to v${rollback_ver} (source: ${rollback_source})"
     if cmd_install_version "$rollback_ver" --source "$rollback_source"; then
         rm -f "$rollback_file"
+        log_info "Rollback to v${rollback_ver} complete"
     else
+        log_error "Rollback to v${rollback_ver} failed"
         return 1
     fi
 }
@@ -680,6 +683,8 @@ do_uninstall() {
     if [ "$cleanup_failed" = "1" ]; then
         log_warn "Some managed directories were skipped because they failed safety checks"
     fi
+
+    log_info "Tailscale uninstall finished (state file preserved at ${STATE_FILE})"
 
     echo ""
     echo "============================================="
@@ -789,6 +794,242 @@ do_status() {
         /usr/bin/tailscale status 2>/dev/null || echo "  (not connected or not running)"
     fi
     echo ""
+}
+
+# ============================================================================
+# Logs & Diagnostics
+# ============================================================================
+
+# Default number of lines shown by `logs` and bundled in `diagnostics`.
+# Matches the amount the bug report template asks contributors to paste.
+TS_LOG_DEFAULT_LINES=200
+
+# Print the tail of a single log file under a labelled header.
+_print_log_section() {
+    local label="$1"
+    local file="$2"
+    local lines="$3"
+
+    echo "=== ${label} (${file}) ==="
+    if [ -f "$file" ]; then
+        tail -n "$lines" "$file" 2>/dev/null || echo "(failed to read ${file})"
+    else
+        echo "(not found)"
+    fi
+    echo ""
+}
+
+# Print recent system log entries mentioning tailscale via logread.
+_print_logread_section() {
+    local lines="$1"
+
+    echo "=== System log (logread, tailscale) ==="
+    if command -v logread >/dev/null 2>&1; then
+        if logread -e tailscale >/dev/null 2>&1; then
+            logread -e tailscale 2>/dev/null | tail -n "$lines"
+        else
+            logread 2>/dev/null | grep -i tailscale | tail -n "$lines" || true
+        fi
+    else
+        echo "(logread not available)"
+    fi
+    echo ""
+}
+
+# `logs [n]` — show the last n lines of every Tailscale log source at once.
+# Bundles the three files plus logread so users no longer have to remember the
+# individual paths/commands listed in the issue template.
+do_logs() {
+    local lines="${1:-$TS_LOG_DEFAULT_LINES}"
+    case "$lines" in
+        '' | *[!0-9]*) lines="$TS_LOG_DEFAULT_LINES" ;;
+    esac
+
+    echo ""
+    echo "============================================="
+    echo "  Tailscale Logs (last ${lines} lines)"
+    echo "============================================="
+    echo ""
+    _print_log_section "Manager log" "$LOG_FILE" "$lines"
+    _print_log_section "Service log" "/var/log/tailscale.log" "$lines"
+    _print_log_section "Auto-update log" "/var/log/tailscale-update.log" "$lines"
+    _print_logread_section "$lines"
+}
+
+# Best-effort device model string for diagnostics output.
+_diag_device_model() {
+    if [ -r /tmp/sysinfo/model ]; then
+        cat /tmp/sysinfo/model 2>/dev/null || echo "unknown"
+    elif [ -r /proc/device-tree/model ]; then
+        tr -d '\0' < /proc/device-tree/model 2>/dev/null || echo "unknown"
+    else
+        echo "unknown"
+    fi
+}
+
+# Report whether a command is present, and what it is needed for when missing.
+_diag_check_cmd() {
+    local name="$1"
+    local purpose="$2"
+    if command -v "$name" >/dev/null 2>&1; then
+        echo "  ${name}: ok ($(command -v "$name"))"
+    else
+        echo "  ${name}: MISSING (needed for ${purpose})"
+    fi
+}
+
+# `diagnostics` (alias `doctor`) — one-shot troubleshooting report.
+# Collects everything the bug report template asks for (versions, platform,
+# install/runtime state, dependency checks, UCI config) plus recent log
+# excerpts, so a user can paste a single block into a GitHub issue.
+do_diagnostics() {
+    local log_lines="${1:-100}"
+    case "$log_lines" in
+        '' | *[!0-9]*) log_lines=100 ;;
+    esac
+
+    local now arch raw_arch
+    now=$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null) || now="unknown"
+    raw_arch=$(uname -m 2>/dev/null) || raw_arch="unknown"
+    arch=$(get_arch 2>/dev/null) || arch="unsupported"
+
+    echo "============================================="
+    echo "  Tailscale Manager Diagnostics"
+    echo "============================================="
+    echo "Generated: ${now}"
+    echo "Copy everything below into your GitHub issue."
+    echo ""
+
+    echo "[Manager]"
+    echo "  Version:        ${VERSION}"
+    echo "  Path:           ${MANAGER_BIN_PATH}"
+    echo "  TAILSCALE_SOURCE env: ${TAILSCALE_SOURCE:-unset}"
+    echo ""
+
+    echo "[System]"
+    if [ -r /etc/openwrt_release ]; then
+        sed -n 's/^\(DISTRIB_[A-Z_]*\)=/  \1=/p' /etc/openwrt_release 2>/dev/null || true
+    else
+        echo "  /etc/openwrt_release: not found"
+    fi
+    echo "  Device model:   $(_diag_device_model)"
+    echo "  Kernel:         $(uname -sr 2>/dev/null || echo unknown)"
+    echo "  Machine:        ${raw_arch}"
+    echo "  Detected arch:  ${arch}"
+    echo ""
+
+    local bin_dir="" installed_ver="not installed" source_type="unknown" storage_mode=""
+    if [ -f "$CONFIG_FILE" ] && [ -r /lib/functions.sh ]; then
+        . /lib/functions.sh
+        config_load tailscale 2>/dev/null || true
+        config_get bin_dir settings bin_dir ""
+        config_get storage_mode settings storage_mode ""
+    fi
+    [ -n "$bin_dir" ] || bin_dir="$PERSISTENT_DIR"
+    installed_ver=$(get_installed_version "$bin_dir")
+    if [ "$installed_ver" = "not installed" ] && [ -f "${RAM_DIR}/version" ]; then
+        bin_dir="$RAM_DIR"
+        storage_mode="${storage_mode:-ram}"
+        installed_ver=$(get_installed_version "$bin_dir")
+    fi
+    if [ -f "${bin_dir}/source" ]; then
+        source_type=$(cat "${bin_dir}/source" 2>/dev/null || echo unknown)
+    elif [ -f "${bin_dir}/tailscale.combined" ]; then
+        source_type="small"
+    fi
+
+    echo "[Tailscale]"
+    echo "  Installed version: ${installed_ver}"
+    echo "  Source:            ${source_type}"
+    echo "  Storage mode:      ${storage_mode:-unknown}"
+    echo "  Binary dir:        ${bin_dir}"
+    if command -v tailscale >/dev/null 2>&1; then
+        echo "  tailscale binary:  $(tailscale version 2>/dev/null | head -n1 || echo unknown)"
+    fi
+    echo ""
+
+    echo "[Service]"
+    echo "  Configured net mode: $(get_configured_net_mode)"
+    if is_tailscaled_running; then
+        local pid
+        pid=$(get_tailscaled_pid 2>/dev/null || true)
+        if [ -n "$pid" ]; then
+            echo "  tailscaled:          running (PID ${pid})"
+        else
+            echo "  tailscaled:          running"
+        fi
+        if is_tailscaled_userspace; then
+            echo "  Active mode:         userspace"
+        else
+            echo "  Active mode:         tun"
+        fi
+    else
+        echo "  tailscaled:          not running"
+    fi
+    local au
+    au=$(get_auto_update_config)
+    if [ "$au" = "1" ]; then
+        if crontab -l 2>/dev/null | grep -Fq "$CRON_SCRIPT"; then
+            echo "  Auto-update:         enabled (cron active)"
+        else
+            echo "  Auto-update:         enabled (cron missing)"
+        fi
+    else
+        echo "  Auto-update:         disabled"
+    fi
+    if type detect_firewall_backend >/dev/null 2>&1; then
+        echo "  Firewall backend:    $(detect_firewall_backend 2>/dev/null || echo unknown)"
+    fi
+    echo ""
+
+    echo "[Dependencies]"
+    _diag_check_cmd wget "downloading binaries"
+    if command -v wget >/dev/null 2>&1; then
+        if wget -q -T 5 --spider "$TAILSCALE_OFFICIAL_BASE_URL" 2>/dev/null; then
+            echo "  HTTPS reachability: ok (${TAILSCALE_OFFICIAL_BASE_URL})"
+        else
+            echo "  HTTPS reachability: FAILED (check SSL libs / network)"
+        fi
+    fi
+    if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+        echo "  ca-bundle:          present"
+    else
+        echo "  ca-bundle:          MISSING"
+    fi
+    if kernel_tun_available; then
+        echo "  TUN device:         available (/dev/net/tun)"
+    else
+        echo "  TUN device:         unavailable (userspace fallback)"
+    fi
+    _diag_check_cmd iptables "firewall rules"
+    _diag_check_cmd jsonfilter "LuCI JSON status"
+    _diag_check_cmd uci "UCI configuration"
+    echo ""
+
+    echo "[Tailscale connection]"
+    if is_tailscaled_running && command -v tailscale >/dev/null 2>&1; then
+        tailscale status 2>&1 | head -n 40 || echo "  (status unavailable)"
+    else
+        echo "  (tailscaled not running)"
+    fi
+    echo ""
+
+    echo "[UCI config: tailscale]"
+    if command -v uci >/dev/null 2>&1; then
+        uci -q show tailscale 2>/dev/null || echo "  (no tailscale UCI config)"
+    else
+        echo "  (uci not available)"
+    fi
+    echo ""
+
+    _print_log_section "Manager log" "$LOG_FILE" "$log_lines"
+    _print_log_section "Service log" "/var/log/tailscale.log" "$log_lines"
+    _print_log_section "Auto-update log" "/var/log/tailscale-update.log" "$log_lines"
+    _print_logread_section "$log_lines"
+
+    echo "============================================="
+    echo "  End of diagnostics"
+    echo "============================================="
 }
 
 do_install_version() {
@@ -976,6 +1217,7 @@ do_download_only() {
     local version
     version=$(get_latest_version "$arch") || return 1
 
+    log_info "Download-only: fetching Tailscale v${version} (source=${DOWNLOAD_SOURCE}, arch=${arch}) into ${bin_dir}"
     download_tailscale "$version" "$arch" "$bin_dir"
 }
 

--- a/usr/lib/tailscale/menu.sh
+++ b/usr/lib/tailscale/menu.sh
@@ -13,7 +13,7 @@ show_menu() {
     if [ -n "$update_hint" ]; then
         echo ""
         echo "  * Management update available: v${update_hint}"
-        echo "    Choose 11 to reinstall the management layer."
+        echo "    Choose 12 to reinstall the management layer."
     fi
     echo ""
     echo "  1) Install Tailscale"
@@ -22,11 +22,12 @@ show_menu() {
     echo "  4) Restart Tailscale"
     echo "  5) Check Status"
     echo "  6) View Logs"
-    echo "  7) Setup Subnet Routing"
-    echo "  8) Install Specific Version (Downgrade)"
-    echo "  9) Auto-Update Settings"
-    echo " 10) Networking Mode Settings"
-    echo " 11) Update Management Scripts"
+    echo "  7) Collect Diagnostics"
+    echo "  8) Setup Subnet Routing"
+    echo "  9) Install Specific Version (Downgrade)"
+    echo " 10) Auto-Update Settings"
+    echo " 11) Networking Mode Settings"
+    echo " 12) Update Management Scripts"
     echo ""
     echo "  0) Exit"
     echo ""
@@ -68,22 +69,19 @@ do_update_scripts() {
 }
 
 do_view_logs() {
-    echo ""
-    echo "=== Manager Log (${LOG_FILE}) ==="
-    if [ -f "$LOG_FILE" ]; then
-        tail -50 "$LOG_FILE"
-    else
-        echo "(no logs yet)"
-    fi
+    # Reuse the shared `logs` renderer (commands.sh) so the menu and CLI stay
+    # in sync. A shorter tail keeps the interactive view readable.
+    do_logs 50
+    printf "Press Enter to continue..."
+    read -r _
+}
 
+do_collect_diagnostics() {
+    local out="/tmp/tailscale-diagnostics.txt"
+    do_diagnostics | tee "$out"
     echo ""
-    echo "=== Service Log (/var/log/tailscale.log) ==="
-    if [ -f /var/log/tailscale.log ]; then
-        tail -50 /var/log/tailscale.log
-    else
-        echo "(no logs yet)"
-    fi
-
+    echo "Saved a copy to: ${out}"
+    echo "Share it in a GitHub issue with: cat ${out}"
     echo ""
     printf "Press Enter to continue..."
     read -r _
@@ -190,11 +188,12 @@ interactive_menu() {
             4) do_restart; printf "Press Enter to continue..."; read -r _ ;;
             5) do_status; printf "Press Enter to continue..."; read -r _ ;;
             6) do_view_logs ;;
-            7) do_setup_subnet_routing; printf "Press Enter to continue..."; read -r _ ;;
-            8) do_install_version; printf "Press Enter to continue..."; read -r _ ;;
-            9) do_auto_update_settings; printf "Press Enter to continue..."; read -r _ ;;
-            10) do_net_mode_settings; printf "Press Enter to continue..."; read -r _ ;;
-            11) do_update_scripts; update_hint=""; printf "Press Enter to continue..."; read -r _ ;;
+            7) do_collect_diagnostics ;;
+            8) do_setup_subnet_routing; printf "Press Enter to continue..."; read -r _ ;;
+            9) do_install_version; printf "Press Enter to continue..."; read -r _ ;;
+            10) do_auto_update_settings; printf "Press Enter to continue..."; read -r _ ;;
+            11) do_net_mode_settings; printf "Press Enter to continue..."; read -r _ ;;
+            12) do_update_scripts; update_hint=""; printf "Press Enter to continue..."; read -r _ ;;
             0) echo "Goodbye!"; exit 0 ;;
             *) echo "Invalid choice" ;;
         esac


### PR DESCRIPTION
## Background
The issue template already guides users to attach logs (`logread -e tailscale`, `/var/log/tailscale-manager.log`, etc.), but the project previously had no corresponding commands. Users had to remember each path individually and manually piece together information, resulting in many issues lacking sufficient diagnostic data. In addition, some key nodes were missing logs.

## Changes

### New Commands
- **`logs [n]`**: Outputs the most recent n lines (default 200, matching the issue template) of the manager / service / auto-update / system (`logread`) logs in one go.
- **`diagnostics`** (alias `doctor`): Generates a complete troubleshooting report with a single command, covering version, device/system information, installation and runtime status, dependency and HTTPS connectivity checks, UCI configuration, and recent log excerpts. The fields correspond one-to-one with the bug template, allowing the entire report to be copied and pasted directly into an issue.
- The interactive menu now includes a **“Collect Diagnostics”** option, and the report is also saved to `/tmp/tailscale-diagnostics.txt`. “View Logs” reuses the unified `logs` rendering logic.

### Improved Logging System (Key Nodes Supplemented)
- Added logging at critical points such as rollback, uninstallation completion, memory-mode `download-only`, and runtime library bootstrapping.
- State-change commands (install/update/uninstall/…) now leave invocation records in the manager log (written only to file to avoid flooding from LuCI polling).
- `LOG_FILE` now supports environment-variable override, allowing the manager log to be placed in a persistent directory (the default `/var/log` is tmpfs and is cleared on reboot). This also makes the existing `LOG_FILE` override in the test framework actually take effect.

### Documentation / Version
- Version bumped from 4.4.0 to 4.5.0; updated Chinese and English changelogs, command reference, troubleshooting documentation, and README.
- Bug template now recommends `tailscale-manager diagnostics` / `logs` as the preferred method.

## Testing
- Added `tests/bats/cli/diagnostics.bats` (5 test cases covering log line counts, log partitions, diagnostics sections, the `doctor` alias, and the HTTPS connectivity failure branch).
- `make lint` (syntax / check-sync / shellcheck / check-static) passes.
- `make test-bats` – all 189 test cases pass.
- Verified with `dash` that `diagnostics` runs correctly under a POSIX shell.

## Optional Follow-up
- A one-click “Diagnostic Report” entry could be added to LuCI (reusing `diagnostics`); this PR does not include it to keep the scope focused.