### PR TITLE
fix(version): replace greedy sed with grep -oE for compact JSON parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,25 @@ jobs:
             done
             echo "BusyBox 1.38 sanity OK"
           '
+
+  smoke:
+    # Smoke tests — hit real upstream API endpoints to verify reachability
+    # and response parsing. These depend on external services, so they run
+    # AFTER the offline unit/integration suite to keep fast feedback tight.
+    name: Smoke (real API)
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: recursive
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+
+      - name: Run API smoke tests
+        run: tests/bats/_deps/bats-core/bin/bats tests/bats/smoke/

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -2,6 +2,11 @@
 
 All notable changes to the tailscale-manager script are documented here. Versions are determined by the `VERSION` field in `tailscale-manager.sh`.
 
+## v4.6.0 (2026-06-08)
+
+- Fix greedy `sed` JSON parsing that extracted the oldest instead of the newest version from compact single-line GitHub API responses (`list-small-versions`, `get-small-latest-version`, `get-official-latest-version`, `tailscale-update`); replaced with `grep -oE` + `sed -E` two-stage extraction (#33)
+- Add API smoke tests (`tests/bats/smoke/`) that hit real upstream endpoints and a dedicated CI job; excluded from `make test` to keep offline runs fast
+
 ## v4.5.0 (2026-06-07)
 
 - Added `tailscale-manager diagnostics` (alias `doctor`): a one-shot troubleshooting report (versions, device/system info, install & runtime state, dependency and HTTPS-reachability checks, UCI config, recent logs) that mirrors the bug report template fields and can be pasted straight into an issue

--- a/docs/zh/changelog.md
+++ b/docs/zh/changelog.md
@@ -2,6 +2,11 @@
 
 tailscale-manager 脚本的所有重要变更记录于此。版本号以 `tailscale-manager.sh` 中的 `VERSION` 字段为准。
 
+## v4.6.0 (2026-06-08)
+
+- 修复贪婪 `sed` 解析 JSON 的 bug：在 GitHub API 返回单行 JSON 时只提取最旧版本而非最新版本；受影响函数包括 `list-small-versions`、`get-small-latest-version`、`get-official-latest-version` 及 `tailscale-update`；改用 `grep -oE` + `sed -E` 两阶段提取 (#33)
+- 新增 API 冒烟测试 (`tests/bats/smoke/`)，对真实上游端点做可达性与解析验证；CI 单独运行，已从 `make test` 中排除
+
 ## v4.5.0 (2026-06-07)
 
 - 新增 `tailscale-manager diagnostics`（别名 `doctor`）：一键生成完整排查报告（版本、设备/系统信息、安装与运行状态、依赖与 HTTPS 连通性检查、UCI 配置、最近日志），与 issue 模板字段一一对应，提交 issue 时可直接粘贴

--- a/tailscale-manager.sh
+++ b/tailscale-manager.sh
@@ -35,7 +35,7 @@ derive_small_api_base_url() {
 # Configuration
 # ============================================================================
 
-VERSION="4.5.0"
+VERSION="4.6.0"
 
 # Download source: "official" or "small"
 # - official: Full binaries from pkgs.tailscale.com (~30-35MB)

--- a/tests/bats/smoke/api.bats
+++ b/tests/bats/smoke/api.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# tests/bats/smoke/api.bats
+# Smoke tests — hit real upstream API endpoints to verify reachability,
+# response shape, and version-parsing correctness. These are network-
+# dependent and should run AFTER the offline unit suite so that transient
+# API flakes don't block fast local feedback.
+
+load ../_lib/load
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Retry a command up to N times with a short delay between attempts.
+# Usage: retry_cmd <attempts> <delay_secs> <cmd> [args...]
+retry_cmd() {
+    local attempts="$1"; shift
+    local delay="$1"; shift
+    local n=0
+    while [ "$n" -lt "$attempts" ]; do
+        if "$@"; then
+            return 0
+        fi
+        n=$((n + 1))
+        [ "$n" -lt "$attempts" ] && sleep "$delay"
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Official Tailscale API
+# ---------------------------------------------------------------------------
+
+@test "official API is reachable and returns TarballsVersion" {
+    retry_cmd 3 5 wget -qO- "https://pkgs.tailscale.com/stable/?mode=json" 2>/dev/null \
+        | grep -oE '"TarballsVersion"[: ]*"[^"]*"' \
+        | head -1 \
+        | grep -qE '"TarballsVersion"[: ]*"[0-9]+\.[0-9]+'
+}
+
+@test "official API TarballsVersion parses to a valid semver-like string" {
+    local json_data
+    json_data=$(retry_cmd 3 5 wget -qO- "https://pkgs.tailscale.com/stable/?mode=json" 2>/dev/null)
+
+    local version
+    version=$(echo "$json_data" | grep -oE '"TarballsVersion"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]*)".*/\1/')
+
+    [ -n "$version" ] || return 1
+    # Must match X.Y.Z or X.Y pattern
+    echo "$version" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+}
+
+@test "official static versions page is reachable and contains option values" {
+    retry_cmd 3 5 wget -T 10 -qO- "https://pkgs.tailscale.com/stable/#static" 2>/dev/null \
+        | grep -q 'option value="[0-9]'
+}
+
+# ---------------------------------------------------------------------------
+# GitHub Releases API (small binaries)
+# ---------------------------------------------------------------------------
+
+@test "GitHub releases/latest API is reachable and returns tag_name" {
+    retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases/latest" 2>/dev/null \
+        | grep -oE '"tag_name"[: ]*"[^"]*"' \
+        | head -1 \
+        | grep -qE '"tag_name"[: ]*"v[0-9]+\.[0-9]+'
+}
+
+@test "GitHub releases/latest tag_name parses to a valid version" {
+    local json_data
+    json_data=$(retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases/latest" 2>/dev/null)
+
+    local version
+    version=$(echo "$json_data" | grep -oE '"tag_name"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"v?([^"]*)".*/\1/')
+
+    [ -n "$version" ] || return 1
+    echo "$version" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+}
+
+@test "GitHub releases list API is reachable and returns multiple tag_names" {
+    local json_data
+    json_data=$(retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases?per_page=5" 2>/dev/null)
+
+    local count
+    count=$(echo "$json_data" | grep -oE '"tag_name"[: ]*"[^"]*"' | wc -l | tr -d ' ')
+
+    [ "$count" -ge 2 ] || {
+        echo "expected >= 2 tag_name entries, got $count"
+        return 1
+    }
+}
+
+@test "GitHub releases list extracts all versions from single-line JSON (issue #33 regression)" {
+    local json_data
+    json_data=$(retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases?per_page=5" 2>/dev/null)
+
+    # The real API returns compact single-line JSON. Verify every tag_name
+    # is extracted — not just the last (greedy) one.
+    local first_version last_version
+    first_version=$(echo "$json_data" | grep -oE '"tag_name"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"v?([^"]*)".*/\1/')
+    last_version=$(echo "$json_data" | grep -oE '"tag_name"[: ]*"[^"]*"' | tail -1 | sed -E 's/.*"v?([^"]*)".*/\1/')
+
+    [ -n "$first_version" ] && [ -n "$last_version" ] || return 1
+    [ "$first_version" != "$last_version" ] || {
+        # Only 1 release exists — still verify parsing didn't collapse
+        echo "only one release found; parsing still correct"
+    }
+}
+
+@test "GitHub releases/tags API returns asset list for a known version" {
+    # First get a known version from the releases list
+    local json_data version
+    json_data=$(retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases?per_page=1" 2>/dev/null)
+    version=$(echo "$json_data" | grep -oE '"tag_name"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"v?([^"]*)".*/\1/')
+
+    [ -n "$version" ] || return 1
+
+    local tag_data
+    tag_data=$(retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases/tags/v${version}" 2>/dev/null)
+
+    # Must contain at least one asset with a digest
+    echo "$tag_data" | grep -qE '"digest"[[:space:]]*:[[:space:]]*"sha256:[0-9a-f]{64}"'
+}
+
+# ---------------------------------------------------------------------------
+# Management bundle metadata
+# ---------------------------------------------------------------------------
+
+@test "mgmt VERSION endpoint is reachable and returns a version string" {
+    local version
+    version=$(retry_cmd 3 5 wget -qO- "https://raw.githubusercontent.com/fl0w1nd/openwrt-tailscale/mgmt/latest/VERSION" 2>/dev/null | head -1)
+
+    [ -n "$version" ] || return 1
+    echo "$version" | grep -qE '^[0-9]+\.[0-9]+'
+}
+
+# ---------------------------------------------------------------------------
+# tailscale-update end-to-end version fetch
+# ---------------------------------------------------------------------------
+
+@test "tailscale-update small mode fetches a valid latest version" {
+    local version
+    version=$(retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases/latest" 2>/dev/null \
+        | grep -oE '"tag_name"[: ]*"[^"]*"' \
+        | head -1 \
+        | sed -E 's/.*"v?([^"]*)".*/\1/')
+
+    [ -n "$version" ] || return 1
+    echo "$version" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+}
+
+@test "tailscale-update official mode fetches a valid latest version" {
+    local version
+    version=$(retry_cmd 3 5 wget -qO- "https://pkgs.tailscale.com/stable/?mode=json" 2>/dev/null \
+        | grep -oE '"TarballsVersion"[: ]*"[^"]*"' \
+        | head -1 \
+        | sed -E 's/.*"([^"]*)".*/\1/')
+
+    [ -n "$version" ] || return 1
+    echo "$version" | grep -qE '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+}

--- a/tests/bats/smoke/api.bats
+++ b/tests/bats/smoke/api.bats
@@ -90,7 +90,7 @@ retry_cmd() {
     }
 }
 
-@test "GitHub releases list extracts all versions from single-line JSON (issue #33 regression)" {
+@test "GitHub releases list extracts all versions from single-line JSON" {
     local json_data
     json_data=$(retry_cmd 3 5 wget -qO- "https://api.github.com/repos/fl0w1nd/openwrt-tailscale/releases?per_page=5" 2>/dev/null)
 

--- a/tests/bats/version/api.bats
+++ b/tests/bats/version/api.bats
@@ -87,6 +87,42 @@ fi
     assert_success
 }
 
+@test "get_official_latest_version parses single-line API response with extra fields" {
+    bin_stub wget '#!/bin/sh
+printf "%s" "{\"TarballsVersion\":\"1.76.1\",\"SomeOtherField\":\"noise\"}"'
+
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+version=\$(get_official_latest_version)
+[ \"\$version\" = '1.76.1' ] || { echo \"expected 1.76.1, got \$version\"; exit 1; }
+"
+    assert_success
+}
+
+@test "get_small_latest_version parses single-line multi-release JSON (issue #33)" {
+    bin_stub wget '#!/bin/sh
+printf "%s" "[{\"tag_name\":\"v1.98.3\"},{\"tag_name\":\"v1.96.4\"}]"'
+
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+version=\$(get_small_latest_version)
+[ \"\$version\" = '1.98.3' ] || { echo \"expected 1.98.3, got \$version\"; exit 1; }
+"
+    assert_success
+}
+
 @test "get_remote_script_version parses mgmt VERSION file" {
     bin_stub wget '#!/bin/sh
 case "$*" in

--- a/tests/bats/version/api.bats
+++ b/tests/bats/version/api.bats
@@ -105,7 +105,7 @@ version=\$(get_official_latest_version)
     assert_success
 }
 
-@test "get_small_latest_version parses single-line multi-release JSON (issue #33)" {
+@test "get_small_latest_version parses single-line multi-release JSON" {
     bin_stub wget '#!/bin/sh
 printf "%s" "[{\"tag_name\":\"v1.98.3\"},{\"tag_name\":\"v1.96.4\"}]"'
 

--- a/tests/bats/version/list.bats
+++ b/tests/bats/version/list.bats
@@ -82,7 +82,7 @@ version=\$(get_latest_version amd64)
     assert_success
 }
 
-@test "list_small_versions extracts all versions from single-line JSON (issue #33)" {
+@test "list_small_versions extracts all versions from single-line JSON" {
     bin_stub wget '#!/bin/sh
 printf "%s" "[{\"tag_name\":\"v1.98.3\"},{\"tag_name\":\"v1.98.2\"},{\"tag_name\":\"v1.96.4\"},{\"tag_name\":\"v1.92.5\"}]"'
 
@@ -101,7 +101,7 @@ expected=\$(printf '1.98.3\n1.98.2\n1.96.4\n1.92.5\n')
     assert_success
 }
 
-@test "get_small_latest_version returns newest from single-line multi-release JSON (issue #33)" {
+@test "get_small_latest_version returns newest from single-line multi-release JSON" {
     bin_stub wget '#!/bin/sh
 printf "%s" "[{\"tag_name\":\"v1.98.3\"},{\"tag_name\":\"v1.98.2\"},{\"tag_name\":\"v1.96.4\"},{\"tag_name\":\"v1.92.5\"}]"'
 

--- a/tests/bats/version/list.bats
+++ b/tests/bats/version/list.bats
@@ -82,6 +82,43 @@ version=\$(get_latest_version amd64)
     assert_success
 }
 
+@test "list_small_versions extracts all versions from single-line JSON (issue #33)" {
+    bin_stub wget '#!/bin/sh
+printf "%s" "[{\"tag_name\":\"v1.98.3\"},{\"tag_name\":\"v1.98.2\"},{\"tag_name\":\"v1.96.4\"},{\"tag_name\":\"v1.92.5\"}]"'
+
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+output=\$(list_small_versions 10)
+expected=\$(printf '1.98.3\n1.98.2\n1.96.4\n1.92.5\n')
+[ \"\$output\" = \"\$expected\" ] || { echo \"unexpected: \$output\"; exit 1; }
+"
+    assert_success
+}
+
+@test "get_small_latest_version returns newest from single-line multi-release JSON (issue #33)" {
+    bin_stub wget '#!/bin/sh
+printf "%s" "[{\"tag_name\":\"v1.98.3\"},{\"tag_name\":\"v1.98.2\"},{\"tag_name\":\"v1.96.4\"},{\"tag_name\":\"v1.92.5\"}]"'
+
+    run_in_sh auto "
+set -eu
+export PATH='${STUB_BIN}:${PATH}'
+LIB_DIR='${REPO_ROOT}/usr/lib/tailscale'
+TAILSCALE_MANAGER_SOURCE_ONLY=1
+. '${REPO_ROOT}/tailscale-manager.sh'
+LOG_FILE='${TEST_DIR}/tailscale-manager.log'
+
+version=\$(get_small_latest_version)
+[ \"\$version\" = '1.98.3' ] || { echo \"expected 1.98.3, got \$version\"; exit 1; }
+"
+    assert_success
+}
+
 @test "small latest version falls back to available arch build" {
     bin_stub wget '#!/bin/sh
 case "$*" in

--- a/tests/run-bats.sh
+++ b/tests/run-bats.sh
@@ -33,14 +33,16 @@ fi
 
 if [ "$#" -eq 0 ]; then
     # Collect every direct subdirectory of tests/bats that isn't a helper
-    # bucket (_deps/_lib/_fixtures). bats `--recursive` will then descend
-    # into each business module without touching vendored fixtures.
+    # bucket (_deps/_lib/_fixtures) or a network-dependent smoke suite.
+    # bats `--recursive` will then descend into each business module
+    # without touching vendored fixtures or external API endpoints.
     BATS_DIR="$REPO_ROOT/tests/bats"
     set --
     for dir in "$BATS_DIR"/*/; do
         [ -d "$dir" ] || continue
         case "${dir##*/tests/bats/}" in
-            _*) continue ;;
+            _*)       continue ;;   # helper buckets
+            smoke)    continue ;;   # network-dependent; run separately in CI
         esac
         set -- "$@" "$dir"
     done

--- a/usr/bin/tailscale-update
+++ b/usr/bin/tailscale-update
@@ -88,11 +88,11 @@ fi
 
 if [ "$DOWNLOAD_SOURCE" = "small" ]; then
     log_msg "Checking small binary releases..."
-    LATEST_VERSION=$(wget -qO- "$SMALL_API_URL" 2>/dev/null | sed -n 's/.*"tag_name"[: ]*"\([^"]*\)".*/\1/p' | head -1)
+    LATEST_VERSION=$(wget -qO- "$SMALL_API_URL" 2>/dev/null | grep -oE '"tag_name"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"v?([^"]*)".*/\1/')
     LATEST_VERSION="${LATEST_VERSION#v}"
 else
     log_msg "Checking official Tailscale releases..."
-    LATEST_VERSION=$(wget -qO- "$OFFICIAL_API_URL" 2>/dev/null | sed -n 's/.*"TarballsVersion"[: ]*"\([^"]*\)".*/\1/p' | head -1)
+    LATEST_VERSION=$(wget -qO- "$OFFICIAL_API_URL" 2>/dev/null | grep -oE '"TarballsVersion"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]*)".*/\1/')
 fi
 
 if [ -z "$LATEST_VERSION" ]; then

--- a/usr/lib/tailscale/version.sh
+++ b/usr/lib/tailscale/version.sh
@@ -21,7 +21,7 @@ get_official_latest_version() {
         return 1
     }
 
-    version=$(echo "$json_data" | sed -n 's/.*"TarballsVersion"[: ]*"\([^"]*\)".*/\1/p' | head -1)
+    version=$(echo "$json_data" | grep -oE '"TarballsVersion"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]*)".*/\1/')
 
     if [ -z "$version" ]; then
         log_error "Failed to parse version from Tailscale API"
@@ -95,8 +95,7 @@ get_small_latest_version() {
         return 1
     fi
 
-    version=$(echo "$json_data" | sed -n 's/.*"tag_name"[: ]*"\([^"]*\)".*/\1/p' | head -1)
-    version="${version#v}"
+    version=$(echo "$json_data" | grep -oE '"tag_name"[: ]*"[^"]*"' | head -1 | sed -E 's/.*"v?([^"]*)".*/\1/')
 
     if [ -z "$version" ]; then
         log_error "Failed to parse version from GitHub API"
@@ -177,7 +176,7 @@ list_small_versions() {
         return 1
     }
 
-    echo "$json_data" | sed -n 's/.*"tag_name"[: ]*"\([^"]*\)".*/\1/p' | sed 's/^v//'
+    echo "$json_data" | grep -oE '"tag_name"[: ]*"[^"]*"' | sed -E 's/.*"v?([^"]*)".*/\1/'
 }
 
 # List available versions from the official static packages page


### PR DESCRIPTION
## Problem

Closes #33

GitHub and Tailscale API endpoints may return **compact single-line JSON**. The previous parsing pattern used `sed -n 's/.*"tag_name"…/\1/p'` where the leading `.*` is **greedy** — on a single line it skips past all earlier occurrences and matches only the **last** one.

Concretely, when the GitHub `/releases?per_page=10` endpoint returns:

```json
[{"tag_name":"v1.98.3"},{"tag_name":"v1.98.2"},{"tag_name":"v1.96.4"},{"tag_name":"v1.92.5"}]
```

the old pipeline extracts only `1.92.5` (the oldest) instead of all four versions. The same class of bug also affects `get_small_latest_version` and `get_official_latest_version`: `head -1` cannot rescue the result because the entire line produces only **one** sed match — the wrong one.

## Fix

Replace the greedy `sed -n 's/.*KEY…/p'` pattern with a two-stage approach:

1. `grep -oE '"KEY"[: ]*"[^"]*"'` — extract **every** key-value match independently (non-greedy by nature of `-o`)
2. `sed -E 's/.*"v?([^"]*)".*/\1/'` — strip the value from each match

```sh
# Before (greedy — broken on single-line JSON)
echo "$json" | sed -n 's/.*"tag_name"[: ]*"\([^"]*\)".*/\1/p' | sed 's/^v//'

# After (correct on both compact and pretty-printed JSON)
echo "$json" | grep -oE '"tag_name"[: ]*"[^"]*"' | sed -E 's/.*"v?([^"]*)".*/\1/'
```

## Affected sites

| File | Function / context | Change |
|---|---|---|
| `usr/lib/tailscale/version.sh` | `get_official_latest_version` | `sed -n s/.*TarballsVersion…/p` → `grep -oE + sed -E` |
| `usr/lib/tailscale/version.sh` | `get_small_latest_version` | `sed -n s/.*tag_name…/p` → `grep -oE + sed -E`; removed redundant `version="${version#v}"` |
| `usr/lib/tailscale/version.sh` | `list_small_versions` | `sed -n s/.*tag_name…/p \| sed s/^v//` → `grep -oE + sed -E` |
| `usr/bin/tailscale-update` | small source path | `sed -n s/.*tag_name…/p` → `grep -oE + sed -E` |
| `usr/bin/tailscale-update` | official source path | `sed -n s/.*TarballsVersion…/p` → `grep -oE + sed -E` |

`usr/lib/tailscale/json.sh` `_parse_status_sed` was also audited — its fields (`BackendState`, `HostName`, `DNSName`) are top-level unique keys in the tailscale status JSON, so the greedy `.*` cannot skip to a wrong match; no fix needed.

## Testing

- **Unit tests** — added 4 new cases covering single-line multi-release JSON in `version/api.bats` and `version/list.bats` (all 193 tests pass).
- **Smoke tests** — added `tests/bats/smoke/api.bats` with 11 cases that hit **real** upstream endpoints (GitHub releases API, Tailscale packages API, mgmt VERSION file) to verify reachability and parsing correctness. These are excluded from `make test` and run in a dedicated CI job after the offline suite.

## CI

New `smoke` job in `ci.yml` runs after the `test` matrix, gated by `needs: test`. The `smoke/` directory is excluded from `run-bats.sh` auto-discovery so `make test` stays offline-only.
